### PR TITLE
Allow overriding treesitter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ plugins = {
   },
 },
 
+-- Overrides
+overrides = {
+  treesitter = {
+    ensure_installed = {"go"}
+  }
+}
+
 -- On/off virtual diagnostics text
 virtual_text = true,
 

--- a/lua/configs/treesitter.lua
+++ b/lua/configs/treesitter.lua
@@ -1,12 +1,14 @@
 local M = {}
 
+local config = require("core.utils").user_settings()
+
 function M.config()
   local status_ok, treesitter = pcall(require, "nvim-treesitter.configs")
   if not status_ok then
     return
   end
 
-  treesitter.setup {
+  default_opts = {
     ensure_installed = {},
     sync_install = false,
     ignore_install = {},
@@ -37,6 +39,8 @@ function M.config()
       enable = true,
     },
   }
+
+  treesitter.setup(vim.tbl_deep_extend("force", {}, default_opts, config.overrides.treesitter))
 end
 
 return M

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -21,6 +21,10 @@ local config = {
     symbols_outline = true,
     indent_blankline = true,
   },
+
+  overrides = {
+    treesitter = {}
+  }
 }
 
 return config


### PR DESCRIPTION
This PR allows overriding the treesitter options to give the user more control.

The main purpose for this was to be able to define the parsers that should be installed in the configuration file without having to install them via command. This allows a faster and easier setup of Neovim on new/other machines.