### PR TITLE
Packer move

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,11 +22,10 @@ end
 
 local config = utils.user_settings()
 
-
 if type(config.polish) == "function" then
   config.polish()
 else
-  error("The polish value in your user configuration must be a function")
+  error "The polish value in your user configuration must be a function"
 end
 
 -- keep this last:

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -33,7 +33,7 @@ local config = {
   --
   -- This function takes no input and AstroVim does not expect it to
   -- return anything either.
-  polish = function() end
+  polish = function() end,
 }
 
 return config

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -28,6 +28,8 @@ local config = {
     ts_autotag = true,
   },
 
+  packer_file = vim.fn.stdpath "config" .. "/lua/packer_compiled.lua",
+
   -- A function called after AstroVim is fully set up.
   -- Use it to override settings or run code.
   --

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -351,7 +351,7 @@ packer.startup {
     end
   end,
   config = {
-    compile_path = vim.fn.stdpath "config" .. "/lua/packer_compiled.lua",
+    compile_path = config.packer_file,
     display = {
       open_fn = function()
         return require("packer.util").float { border = "rounded" }

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -55,9 +55,11 @@ function M.impatient()
 end
 
 function M.compiled()
-  local compiled_ok, _ = pcall(require, "packer_compiled")
-  if compiled_ok then
-    require "packer_compiled"
+  local run_me, _ = loadfile(_user_settings.packer_file)
+  if run_me then
+    run_me()
+  else
+    print "Please run :PackerSync"
   end
 end
 

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -2,6 +2,17 @@ local M = {}
 
 local g = vim.g
 
+local function load_user_settings()
+  local default = require "core.defaults"
+  local user_status_ok, user_settings = pcall(require, "user.settings")
+  if user_status_ok then
+    default = vim.tbl_deep_extend("force", default, user_settings)
+  end
+  return default
+end
+
+local _user_settings = load_user_settings()
+
 function M.bootstrap()
   local fn = vim.fn
   local install_path = fn.stdpath "data" .. "/site/pack/packer/start/packer.nvim"
@@ -33,12 +44,7 @@ function M.disabled_builtins()
 end
 
 function M.user_settings()
-  local default = require "core.defaults"
-  local user_status_ok, user_settings = pcall(require, "user.settings")
-  if user_status_ok then
-    default = vim.tbl_deep_extend("force", default, user_settings)
-  end
-  return default
+  return _user_settings
 end
 
 function M.impatient()

--- a/lua/user/settings.lua
+++ b/lua/user/settings.lua
@@ -46,6 +46,8 @@ local config = {
     ts_rainbow = true,
     ts_autotag = true,
   },
+
+  packer_file = vim.fn.stdpath "config" .. "/lua/packer_compiled.lua",
 }
 
 -- Set options


### PR DESCRIPTION
My config directory is read-only, so Packer fails in AstroVim as it can not write its `packer_compiled.lua` file.

So here is a PR to make that file location configurable. The default is of course the location you currently use:-)