### PR TITLE
Add option to disable bufferline

### DIFF
--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -7,6 +7,7 @@ local config = {
   virtual_text = true,
 
   enabled = {
+    bufferline = true,
     nvim_tree = true,
     lualine = true,
     lspsaga = true,

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -62,12 +62,14 @@ packer.startup {
       config = function()
         require("configs.bufferline").config()
       end,
+      disable = not config.enabled.bufferline,
     }
 
     -- Better buffer closing
     use {
       "moll/vim-bbye",
       after = "bufferline.nvim",
+      disable = not config.enabled.bufferline,
     }
 
     -- File explorer
@@ -84,7 +86,6 @@ packer.startup {
     -- Statusline
     use {
       "nvim-lualine/lualine.nvim",
-      after = "bufferline.nvim",
       config = function()
         require("configs.lualine").config()
       end,


### PR DESCRIPTION
Closes: #39

I think it is safe to remove the `after = "bufferline"` from `lualine`: I could not spot any mention of bufferline in the lualine config.

The history of plugins.lua unfortunately gave no hint why this ordering was considered encessary.