### PR TITLE
Add sheerun/polyglot for extended filetype support

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -20,6 +20,9 @@ packer.startup {
       "lewis6991/impatient.nvim",
     }
 
+    -- Extended file type support
+    use { "sheerun/vim-polyglot" }
+
     -- Lua functions
     use {
       "nvim-lua/plenary.nvim",


### PR DESCRIPTION
["sheerun/vim-polyglot"](https://github.com/sheerun/vim-polyglot)
adds base-line support for a *lot* of file types in one convenient
package.

Base-line support includes: basic syntax highlighting (tree-sitter
highlights way nicer, and is preferred when available, but
at least you get something!), compiler support, filetype detection,
indentation handling, ... .

As a bonus this supposedly loads a lot faster than adding all the
language plugins separately. I admit that this is a pretty useless
benchmark as nobody in their right mind would add so many langauges
into their vim config manually.