### PR TITLE
Disable Ex mode

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -96,4 +96,7 @@ map("x", "K", "<cmd>move '<-2<CR>gv-gv", opts)
 map("x", "<A-j>", "<cmd>move '>+1<CR>gv-gv", opts)
 map("x", "<A-k>", "<cmd>move '<-2<CR>gv-gv", opts)
 
+-- disable Ex mode:
+map("n", "Q", "<Nop>", opts)
+
 return M


### PR DESCRIPTION
Ex-mode is not widely used and it is hard to get out off again,
so disable it by default.