### PR TITLE
Add an optional polish function

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -20,6 +20,14 @@ for _, source in ipairs(sources) do
   end
 end
 
-utils.user_settings()
+local config = utils.user_settings()
 
+
+if type(config.polish) == "function" then
+  config.polish()
+else
+  error("The polish value in your user configuration must be a function")
+end
+
+-- keep this last:
 utils.compiled()

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -27,6 +27,13 @@ local config = {
     ts_rainbow = true,
     ts_autotag = true,
   },
+
+  -- A function called after AstroVim is fully set up.
+  -- Use it to override settings or run code.
+  --
+  -- This function takes no input and AstroVim does not expect it to
+  -- return anything either.
+  polish = function() end
 }
 
 return config


### PR DESCRIPTION
Add an optional polish function into the user settings that is run right
before returning control to neovim. This is a nice place to override
choices made be AstroVim :-)