### PR TITLE
Load nvim-cmp-lsp after nvim-cmp

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -173,6 +173,7 @@ packer.startup {
     -- LSP completion source
     use {
       "hrsh7th/cmp-nvim-lsp",
+      after = "nvim-cmp",
     }
 
     -- LSP manager


### PR DESCRIPTION
This looks wrong, but might be a actually be working around some problem. I am not 100% sure here.