### PR TITLE
Lsp-installer: Allow to override how language servers are registered

### DIFF
--- a/lua/configs/lsp/lsp-installer.lua
+++ b/lua/configs/lsp/lsp-installer.lua
@@ -24,5 +24,5 @@ lsp_installer.on_server_ready(function(server)
     opts = vim.tbl_deep_extend("force", pyright_opts, opts)
   end
 
-  server:setup(opts)
+  require("core.utils").user_settings().overrides.lsp_installer.server_registration_override(server, opts)
 end)

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -5,6 +5,18 @@ local config = {
   plugins = {},
 
   overrides = {
+    lsp_installer = {
+      -- A function used to override how a LSP is registered
+      --
+      -- Gets the server object and the configuration as input and
+      -- will by default just call `server:setup(opts)`.
+      --
+      -- This function usually does not need to be overriden, only special
+      -- LSP integration plugins like `rust-tools.nvim` need this.
+      server_registration_override = function(server, opts)
+        server:setup(opts)
+      end,
+    },
     treesitter = {},
   },
 


### PR DESCRIPTION
This is needed for special plugins like `rust.tools.nvim` that extend
the typical LSP support significantly.

This can also be used to override lsp server settings from the user settings, but we should probably have a nicer thing for that... Users have full control via this override of all data passed into the LSP server registration with this hook.