### PR TITLE
Make lualine display status messages

### DIFF
--- a/lua/configs/lualine.lua
+++ b/lua/configs/lualine.lua
@@ -124,6 +124,43 @@ function M.config()
   }
 
   ins_right {
+    function(_)
+      local Lsp = vim.lsp.util.get_progress_messages()[1]
+
+      if Lsp then
+        local msg = Lsp.message or ""
+        local percentage = Lsp.percentage or 0
+        local title = Lsp.title or ""
+        local spinners = {
+          "",
+          "",
+          "",
+        }
+
+        local success_icon = {
+          "",
+          "",
+          "",
+        }
+
+        local ms = vim.loop.hrtime() / 1000000
+        local frame = math.floor(ms / 120) % #spinners
+
+        if percentage >= 70 then
+          return string.format(" %%<%s %s %s (%s%%%%) ", success_icon[frame + 1], title, msg, percentage)
+        end
+
+        return string.format(" %%<%s %s %s (%s%%%%) ", spinners[frame + 1], title, msg, percentage)
+      end
+
+      return ""
+    end,
+    color = { gui = "none" },
+    padding = { left = 0, right = 1 },
+    cond = conditions.hide_in_width,
+  }
+
+  ins_right {
     function(msg)
       msg = msg or "Inactive"
       local buf_clients = vim.lsp.buf_get_clients()


### PR DESCRIPTION
Code is taken from NVChad under GPL-3.0.

The LSP progress information is *extremely* nice to have when working with a big C++ project, where clangd can take >10min to chew through the entire project before it is ready to actually work!