### PR TITLE
Telescope: Show more of the file path in search

### DIFF
--- a/lua/configs/telescope.lua
+++ b/lua/configs/telescope.lua
@@ -14,7 +14,7 @@ function M.config()
 
       prompt_prefix = " ",
       selection_caret = "❯ ",
-      path_display = { "smart" },
+      path_display = { "truncate" },
 
       mappings = {
         i = {


### PR DESCRIPTION
Not sure this patch makes sense for AstroVim...

The `smart` path_display is unfortunately pretty dumb.

Convention in rust is to have a directory layout like this `[lib_name]/src/lib.rs`. The `smart` policy in Telescope displays those as `.../src/lib.rs` -- for all the libraries and independent of wheether the full path would fit or not! That makes the whole search pretty pointless for me.

`truncate` will just cut off from the start of the file, but at least it will not truncate when there is enough space to display the entire name without truncating anything!