### PR TITLE
Remove Outline from Bufferline

### DIFF
--- a/lua/configs/bufferline.lua
+++ b/lua/configs/bufferline.lua
@@ -24,6 +24,7 @@ function M.config()
       offsets = {
         { filetype = "NvimTree", text = "", padding = 1 },
         { filetype = "neo-tree", text = "", padding = 1 },
+        { filetype = "Outline", text = "", padding = 1 },
       },
       buffer_close_icon = "",
       modified_icon = "",


### PR DESCRIPTION
When the Symbol Outline is part of the Bufferline it causes weird behavior when opening new files and stuff from the file browser when the outline is open and also makes an empty tab for the symbols. Seems to make more sense to ignore it.