### PR TITLE
Allow loading nvim-tree when using focus command

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -75,7 +75,7 @@ packer.startup {
     -- File explorer
     use {
       "kyazdani42/nvim-tree.lua",
-      cmd = {"NvimTreeToggle", "NvimTreeFocus"},
+      cmd = { "NvimTreeToggle", "NvimTreeFocus" },
       commit = "8b27fd4",
       config = function()
         require("configs.nvim-tree").config()

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -75,7 +75,7 @@ packer.startup {
     -- File explorer
     use {
       "kyazdani42/nvim-tree.lua",
-      cmd = "NvimTreeToggle",
+      cmd = {"NvimTreeToggle", "NvimTreeFocus"},
       commit = "8b27fd4",
       config = function()
         require("configs.nvim-tree").config()


### PR DESCRIPTION
This project defines a mapping for `NvimTreeFocus`. This will fail on first use because  nvim-tree is not loaded. 

This change ensures that nvim-tree is loaded if a user calls `NvimTreeFocus` before they have called `NvimTreeToggle`