### PR TITLE
Added editorconfig for sumneko-lua

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.lua]
+max_line_length = 120
+end_of_line = lf
+indent_style = space
+indent_size = 2
+continuation_indent_size = 2


### PR DESCRIPTION
Now that sumneko lua-language-server protocol supports code formatting, when I have stylua and sumneko enabled I got asked every time which language server to use for formatting. It seems like it might be easier to try and move over to the Sumneko editorconfig formatting. I moved over as much stuff as I could, but there are a couple issues.

1. They don't have preferred quote style in the same way as stylua
2. They don't have a feature for no_call_parentheses

not sure if this is a deal breaker, but thought I would at least start the conversation/get the ball rolling