### PR TITLE
Add configuration for yamlls (using schemastore plugin)

### DIFF
--- a/lua/configs/lsp/server-settings/yamlls.lua
+++ b/lua/configs/lsp/server-settings/yamlls.lua
@@ -1,0 +1,9 @@
+local opts = {
+  settings = {
+    yaml = {
+      schemas = require("schemastore").json.schemas(),
+    },
+  },
+}
+
+return opts


### PR DESCRIPTION
This works with the schemastore plugin: I get errors when using invalid keywords in .github action setup yaml files.