### PR TITLE
Better highlight for the Telescope match in the preview

### DIFF
--- a/lua/onedark/others.lua
+++ b/lua/onedark/others.lua
@@ -20,7 +20,7 @@ local others = {
   TelescopeTitle = { fg = C.fg },
   TelescopePromptCounter = { fg = C.grey_1 },
   TelescopePromptPrefix = { fg = C.blue },
-  TelescopePreviewLine = { fg = C.grey_5 },
+  TelescopePreviewLine = { bg = C.grey_5 },
   TelescopePreviewMatch = { fg = C.yellow },
   TelescopePreviewPipe = { fg = C.yellow },
   TelescopePreviewCharDev = { fg = C.yellow },


### PR DESCRIPTION
Leave the forground alone, so syntac highlighting continues to work,
but make the background lighter than the one in the surrounding area.