### PR TITLE
Removed yamlls server settings

### DIFF
--- a/lua/configs/lsp/server-settings/yamlls.lua
+++ b/lua/configs/lsp/server-settings/yamlls.lua
@@ -1,9 +1,0 @@
-local opts = {
-  settings = {
-    yaml = {
-      schemas = require("schemastore").json.schemas(),
-    },
-  },
-}
-
-return opts


### PR DESCRIPTION
This file is not doing anything since `schemastore` is not properly formatted for the yamlls. yamlls in nvim lspconfig has built in schema store compatibility pulling from https://www.schemastore.org/api/json/catalog.json

This makes it appear that it is working with this file, but in actuality it's doing nothing.