### PR TITLE
Enable bbye plugins

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -68,8 +68,6 @@ packer.startup {
     -- Better buffer closing
     use {
       "moll/vim-bbye",
-      after = "bufferline.nvim",
-      disable = not config.enabled.bufferline,
     }
 
     -- File explorer


### PR DESCRIPTION
It just adds a couple of new commands that you do not have to use, so it
does not hurt to enable the plugin unconditionally, even when no
bufferline is installed.

Most users should not notice this as bufferline is enabled by default.