### PR TITLE
Change telescope layout to seem more natural

### DIFF
--- a/lua/configs/telescope.lua
+++ b/lua/configs/telescope.lua
@@ -15,6 +15,22 @@ function M.config()
       prompt_prefix = " ",
       selection_caret = "❯ ",
       path_display = { "truncate" },
+      selection_strategy = "reset",
+      sorting_strategy = "ascending",
+      layout_strategy = "horizontal",
+      layout_config = {
+        horizontal = {
+          prompt_position = "top",
+          preview_width = 0.55,
+          results_width = 0.8,
+        },
+        vertical = {
+          mirror = false,
+        },
+        width = 0.87,
+        height = 0.80,
+        preview_cutoff = 120,
+      },
 
       mappings = {
         i = {


### PR DESCRIPTION
This was discussed briefly in the Discord discussions that maybe we should move the prompt to the top and reverse the results picker. I went ahead and did this locally and figured I would suggest it here. Screenshot below:

![2022-03-03_10:02:22_screenshot](https://user-images.githubusercontent.com/1591837/156591366-4acdfeb9-db8b-4ee2-b386-4e2e6d79e0e8.png)

