### PR TITLE
Allow to polish plugins before loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,25 @@ Just copy the `packer` configuration without the `use` and with a `,` after the 
 
 See the example above.
 
+### Change Configfuration of default Plugins
+
+AstroVim provides a `polish_plugins` function in the user settings that can be used to override the packer
+configuration for all plugins, user plugins as well as plugins configured by AstroVim.
+
+E.g. this code in your `settings.lua` will globally disable the lazy loading that is used by AstroVim by default:
+
+```lua
+  polish_plugins = function(plugins)
+    local result = {}
+    for _, plugin in pairs(plugins) do
+      plugin["cmd"] = nil
+      plugin["event"] = nil
+      table.insert(result, plugin)
+    end
+    return result
+  end
+```
+
 ### Adding sources to `nvim-cmp`
 
 To add new completion sources to `nvim-cmp` you can add the plugin (see above) providing that source like this:

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -53,6 +53,13 @@ local config = {
   -- This function takes no input and AstroVim does not expect it to
   -- return anything either.
   polish = function() end,
+
+  -- A function called during plugin setup. It takes the entire list of plugins
+  -- and provides a user with an opportunity to modify the entire list before
+  -- loading plugins.
+  polish_plugins = function(plugins)
+    return plugins
+  end,
 }
 
 return config

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -1,358 +1,367 @@
 local M = {}
 
-local utils = require "core.utils"
-local config = utils.user_settings()
-
 local packer_status_ok, packer = pcall(require, "packer")
 if not packer_status_ok then
   return
 end
 
+local utils = require "core.utils"
+local config = utils.user_settings()
+
+local astro_plugins = {
+  -- Plugin manager
+  {
+    "wbthomason/packer.nvim",
+  },
+
+  -- Optimiser
+  {
+    "lewis6991/impatient.nvim",
+  },
+
+  -- Lua functions
+  {
+    "nvim-lua/plenary.nvim",
+  },
+
+  -- Popup API
+  {
+    "nvim-lua/popup.nvim",
+  },
+
+  -- Boost startup time
+  {
+    "nathom/filetype.nvim",
+    config = function()
+      vim.g.did_load_filetypes = 1
+    end,
+  },
+
+  -- Cursorhold fix
+  {
+    "antoinemadec/FixCursorHold.nvim",
+    event = "BufRead",
+    config = function()
+      vim.g.cursorhold_updatetime = 100
+    end,
+  },
+
+  -- Icons
+  {
+    "kyazdani42/nvim-web-devicons",
+    config = function()
+      require("configs.icons").config()
+    end,
+  },
+
+  -- Bufferline
+  {
+    "akinsho/bufferline.nvim",
+    after = "nvim-web-devicons",
+    config = function()
+      require("configs.bufferline").config()
+    end,
+    disable = not config.enabled.bufferline,
+  },
+
+  -- Better buffer closing
+  {
+    "moll/vim-bbye",
+  },
+
+  -- File explorer
+  {
+    "kyazdani42/nvim-tree.lua",
+    cmd = { "NvimTreeToggle", "NvimTreeFocus" },
+    commit = "8b27fd4",
+    config = function()
+      require("configs.nvim-tree").config()
+    end,
+    disable = not config.enabled.nvim_tree,
+  },
+
+  -- Statusline
+  {
+    "nvim-lualine/lualine.nvim",
+    commit = "6a3d367",
+    config = function()
+      require("configs.lualine").config()
+    end,
+    disable = not config.enabled.lualine,
+  },
+
+  -- Syntax highlighting
+  {
+    "nvim-treesitter/nvim-treesitter",
+    run = ":TSUpdate",
+    event = "BufRead",
+    cmd = {
+      "TSInstall",
+      "TSInstallInfo",
+      "TSInstallSync",
+      "TSUninstall",
+      "TSUpdate",
+      "TSUpdateSync",
+      "TSDisableAll",
+      "TSEnableAll",
+    },
+    config = function()
+      require("configs.treesitter").config()
+    end,
+    requires = {
+      {
+        -- Parenthesis highlighting
+        "p00f/nvim-ts-rainbow",
+        after = "nvim-treesitter",
+        disable = not config.enabled.ts_rainbow,
+      },
+      {
+        -- Autoclose tags
+        "windwp/nvim-ts-autotag",
+        after = "nvim-treesitter",
+        disable = not config.enabled.ts_autotag,
+      },
+      {
+        -- Context based commenting
+        "JoosepAlviste/nvim-ts-context-commentstring",
+        after = "nvim-treesitter",
+      },
+    },
+  },
+
+  -- Snippet engine
+  {
+    "L3MON4D3/LuaSnip",
+    config = function()
+      local settings = require("core.utils").user_settings()
+      local loader = require "luasnip/loaders/from_vscode"
+      loader.lazy_load { paths = settings.overrides.luasnip.vscode_snippets_paths }
+      loader.lazy_load()
+    end,
+    requires = {
+      -- Snippet collections
+      "rafamadriz/friendly-snippets",
+    },
+  },
+
+  -- Completion engine
+  {
+    "hrsh7th/nvim-cmp",
+    event = "BufRead",
+    config = function()
+      require("configs.cmp").config()
+    end,
+  },
+
+  -- Snippet completion source
+  {
+    "saadparwaiz1/cmp_luasnip",
+    after = "nvim-cmp",
+  },
+
+  -- Buffer completion source
+  {
+    "hrsh7th/cmp-buffer",
+    after = "nvim-cmp",
+  },
+
+  -- Path completion source
+  {
+    "hrsh7th/cmp-path",
+    after = "nvim-cmp",
+  },
+
+  -- LSP completion source
+  {
+    "hrsh7th/cmp-nvim-lsp",
+  },
+
+  -- LSP manager
+  {
+    "williamboman/nvim-lsp-installer",
+    event = "BufRead",
+    cmd = {
+      "LspInstall",
+      "LspInstallInfo",
+      "LspPrintInstalled",
+      "LspRestart",
+      "LspStart",
+      "LspStop",
+      "LspUninstall",
+      "LspUninstallAll",
+    },
+  },
+
+  -- Built-in LSP
+  {
+    "neovim/nvim-lspconfig",
+    event = "BufRead",
+    config = function()
+      require "configs.lsp"
+    end,
+  },
+
+  -- LSP enhancer
+  {
+    "tami5/lspsaga.nvim",
+    event = "BufRead",
+    config = function()
+      require("configs.lsp.lspsaga").config()
+    end,
+    disable = not config.enabled.lspsaga,
+  },
+
+  -- LSP symbols
+  {
+    "simrat39/symbols-outline.nvim",
+    cmd = "SymbolsOutline",
+    setup = function()
+      require("configs.symbols-outline").setup()
+    end,
+    disable = not config.enabled.symbols_outline,
+  },
+
+  -- Formatting and linting
+  {
+    "jose-elias-alvarez/null-ls.nvim",
+    event = "BufRead",
+    config = function()
+      require("user.null-ls").config()
+    end,
+  },
+
+  -- Fuzzy finder
+  {
+    "nvim-telescope/telescope.nvim",
+    cmd = "Telescope",
+    config = function()
+      require("configs.telescope").config()
+    end,
+  },
+
+  -- Fuzzy finder syntax support
+  {
+    "nvim-telescope/telescope-fzf-native.nvim",
+    run = "make",
+  },
+
+  -- Git integration
+  {
+    "lewis6991/gitsigns.nvim",
+    event = "BufRead",
+    config = function()
+      require("configs.gitsigns").config()
+    end,
+    disable = not config.enabled.gitsigns,
+  },
+
+  -- Start screen
+  {
+    "glepnir/dashboard-nvim",
+    config = function()
+      require("configs.dashboard").config()
+    end,
+    disable = not config.enabled.dashboard,
+  },
+
+  -- Color highlighting
+  {
+    "norcalli/nvim-colorizer.lua",
+    event = "BufRead",
+    config = function()
+      require("configs.colorizer").config()
+    end,
+    disable = not config.enabled.colorizer,
+  },
+
+  -- Autopairs
+  {
+    "windwp/nvim-autopairs",
+    event = "InsertEnter",
+    config = function()
+      require("configs.autopairs").config()
+    end,
+  },
+
+  -- Terminal
+  {
+    "akinsho/nvim-toggleterm.lua",
+    cmd = "ToggleTerm",
+    config = function()
+      require("configs.toggleterm").config()
+    end,
+    disable = not config.enabled.toggle_term,
+  },
+
+  -- Commenting
+  {
+    "numToStr/Comment.nvim",
+    event = "BufRead",
+    config = function()
+      require("configs.comment").config()
+    end,
+    disable = not config.enabled.comment,
+  },
+
+  -- Indentation
+  {
+    "lukas-reineke/indent-blankline.nvim",
+    config = function()
+      require("configs.indent-line").config()
+    end,
+    disable = not config.enabled.indent_blankline,
+  },
+
+  -- Keymaps popup
+  {
+    "folke/which-key.nvim",
+    config = function()
+      require("configs.which-key").config()
+    end,
+    disable = not config.enabled.which_key,
+  },
+
+  -- Smooth scrolling
+  {
+    "karb94/neoscroll.nvim",
+    event = "BufRead",
+    config = function()
+      require("configs.neoscroll").config()
+    end,
+    disable = not config.enabled.neoscroll,
+  },
+
+  -- Smooth escaping
+  {
+    "max397574/better-escape.nvim",
+    event = { "InsertEnter" },
+    config = function()
+      require("better_escape").setup {
+        mapping = { "ii", "jj", "jk", "kj" },
+        timeout = vim.o.timeoutlen,
+        keys = "<ESC>",
+      }
+    end,
+  },
+
+  -- Get extra JSON schemas
+  { "b0o/SchemaStore.nvim" },
+}
+
 packer.startup {
   function(use)
-    -- Plugin manager
-    use {
-      "wbthomason/packer.nvim",
-    }
+    local plugins = astro_plugins
 
-    -- Optimiser
-    use {
-      "lewis6991/impatient.nvim",
-    }
-
-    -- Lua functions
-    use {
-      "nvim-lua/plenary.nvim",
-    }
-
-    -- Popup API
-    use {
-      "nvim-lua/popup.nvim",
-    }
-
-    -- Boost startup time
-    use {
-      "nathom/filetype.nvim",
-      config = function()
-        vim.g.did_load_filetypes = 1
-      end,
-    }
-
-    -- Cursorhold fix
-    use {
-      "antoinemadec/FixCursorHold.nvim",
-      event = "BufRead",
-      config = function()
-        vim.g.cursorhold_updatetime = 100
-      end,
-    }
-
-    -- Icons
-    use {
-      "kyazdani42/nvim-web-devicons",
-      config = function()
-        require("configs.icons").config()
-      end,
-    }
-
-    -- Bufferline
-    use {
-      "akinsho/bufferline.nvim",
-      after = "nvim-web-devicons",
-      config = function()
-        require("configs.bufferline").config()
-      end,
-      disable = not config.enabled.bufferline,
-    }
-
-    -- Better buffer closing
-    use {
-      "moll/vim-bbye",
-    }
-
-    -- File explorer
-    use {
-      "kyazdani42/nvim-tree.lua",
-      cmd = { "NvimTreeToggle", "NvimTreeFocus" },
-      commit = "8b27fd4",
-      config = function()
-        require("configs.nvim-tree").config()
-      end,
-      disable = not config.enabled.nvim_tree,
-    }
-
-    -- Statusline
-    use {
-      "nvim-lualine/lualine.nvim",
-      commit = "6a3d367",
-      config = function()
-        require("configs.lualine").config()
-      end,
-      disable = not config.enabled.lualine,
-    }
-
-    -- Syntax highlighting
-    use {
-      "nvim-treesitter/nvim-treesitter",
-      run = ":TSUpdate",
-      event = "BufRead",
-      cmd = {
-        "TSInstall",
-        "TSInstallInfo",
-        "TSInstallSync",
-        "TSUninstall",
-        "TSUpdate",
-        "TSUpdateSync",
-        "TSDisableAll",
-        "TSEnableAll",
-      },
-      config = function()
-        require("configs.treesitter").config()
-      end,
-      requires = {
-        {
-          -- Parenthesis highlighting
-          "p00f/nvim-ts-rainbow",
-          after = "nvim-treesitter",
-          disable = not config.enabled.ts_rainbow,
-        },
-        {
-          -- Autoclose tags
-          "windwp/nvim-ts-autotag",
-          after = "nvim-treesitter",
-          disable = not config.enabled.ts_autotag,
-        },
-        {
-          -- Context based commenting
-          "JoosepAlviste/nvim-ts-context-commentstring",
-          after = "nvim-treesitter",
-        },
-      },
-    }
-
-    -- Snippet engine
-    use {
-      "L3MON4D3/LuaSnip",
-      config = function()
-        local settings = require("core.utils").user_settings()
-        local loader = require "luasnip/loaders/from_vscode"
-        loader.lazy_load { paths = settings.overrides.luasnip.vscode_snippets_paths }
-        loader.lazy_load()
-      end,
-      requires = {
-        -- Snippet collections
-        "rafamadriz/friendly-snippets",
-      },
-    }
-
-    -- Completion engine
-    use {
-      "hrsh7th/nvim-cmp",
-      event = "BufRead",
-      config = function()
-        require("configs.cmp").config()
-      end,
-    }
-
-    -- Snippet completion source
-    use {
-      "saadparwaiz1/cmp_luasnip",
-      after = "nvim-cmp",
-    }
-
-    -- Buffer completion source
-    use {
-      "hrsh7th/cmp-buffer",
-      after = "nvim-cmp",
-    }
-
-    -- Path completion source
-    use {
-      "hrsh7th/cmp-path",
-      after = "nvim-cmp",
-    }
-
-    -- LSP completion source
-    use {
-      "hrsh7th/cmp-nvim-lsp",
-    }
-
-    -- LSP manager
-    use {
-      "williamboman/nvim-lsp-installer",
-      event = "BufRead",
-      cmd = {
-        "LspInstall",
-        "LspInstallInfo",
-        "LspPrintInstalled",
-        "LspRestart",
-        "LspStart",
-        "LspStop",
-        "LspUninstall",
-        "LspUninstallAll",
-      },
-    }
-
-    -- Built-in LSP
-    use {
-      "neovim/nvim-lspconfig",
-      event = "BufRead",
-      config = function()
-        require "configs.lsp"
-      end,
-    }
-
-    -- LSP enhancer
-    use {
-      "tami5/lspsaga.nvim",
-      event = "BufRead",
-      config = function()
-        require("configs.lsp.lspsaga").config()
-      end,
-      disable = not config.enabled.lspsaga,
-    }
-
-    -- LSP symbols
-    use {
-      "simrat39/symbols-outline.nvim",
-      cmd = "SymbolsOutline",
-      setup = function()
-        require("configs.symbols-outline").setup()
-      end,
-      disable = not config.enabled.symbols_outline,
-    }
-
-    -- Formatting and linting
-    use {
-      "jose-elias-alvarez/null-ls.nvim",
-      event = "BufRead",
-      config = function()
-        require("user.null-ls").config()
-      end,
-    }
-
-    -- Fuzzy finder
-    use {
-      "nvim-telescope/telescope.nvim",
-      cmd = "Telescope",
-      config = function()
-        require("configs.telescope").config()
-      end,
-    }
-
-    -- Fuzzy finder syntax support
-    use {
-      "nvim-telescope/telescope-fzf-native.nvim",
-      run = "make",
-    }
-
-    -- Git integration
-    use {
-      "lewis6991/gitsigns.nvim",
-      event = "BufRead",
-      config = function()
-        require("configs.gitsigns").config()
-      end,
-      disable = not config.enabled.gitsigns,
-    }
-
-    -- Start screen
-    use {
-      "glepnir/dashboard-nvim",
-      config = function()
-        require("configs.dashboard").config()
-      end,
-      disable = not config.enabled.dashboard,
-    }
-
-    -- Color highlighting
-    use {
-      "norcalli/nvim-colorizer.lua",
-      event = "BufRead",
-      config = function()
-        require("configs.colorizer").config()
-      end,
-      disable = not config.enabled.colorizer,
-    }
-
-    -- Autopairs
-    use {
-      "windwp/nvim-autopairs",
-      event = "InsertEnter",
-      config = function()
-        require("configs.autopairs").config()
-      end,
-    }
-
-    -- Terminal
-    use {
-      "akinsho/nvim-toggleterm.lua",
-      cmd = "ToggleTerm",
-      config = function()
-        require("configs.toggleterm").config()
-      end,
-      disable = not config.enabled.toggle_term,
-    }
-
-    -- Commenting
-    use {
-      "numToStr/Comment.nvim",
-      event = "BufRead",
-      config = function()
-        require("configs.comment").config()
-      end,
-      disable = not config.enabled.comment,
-    }
-
-    -- Indentation
-    use {
-      "lukas-reineke/indent-blankline.nvim",
-      config = function()
-        require("configs.indent-line").config()
-      end,
-      disable = not config.enabled.indent_blankline,
-    }
-
-    -- Keymaps popup
-    use {
-      "folke/which-key.nvim",
-      config = function()
-        require("configs.which-key").config()
-      end,
-      disable = not config.enabled.which_key,
-    }
-
-    -- Smooth scrolling
-    use {
-      "karb94/neoscroll.nvim",
-      event = "BufRead",
-      config = function()
-        require("configs.neoscroll").config()
-      end,
-      disable = not config.enabled.neoscroll,
-    }
-
-    -- Smooth escaping
-    use {
-      "max397574/better-escape.nvim",
-      event = { "InsertEnter" },
-      config = function()
-        require("better_escape").setup {
-          mapping = { "ii", "jj", "jk", "kj" },
-          timeout = vim.o.timeoutlen,
-          keys = "<ESC>",
-        }
-      end,
-    }
-
-    -- Get extra JSON schemas
-    use { "b0o/SchemaStore.nvim" }
-
-    -- User defined plugins
+    -- Append user defined plugins
     if config.plugins and not vim.tbl_isempty(config.plugins) then
       for _, plugin in pairs(config.plugins) do
-        use(plugin)
+        table.insert(plugins, plugin)
       end
+    end
+
+    -- Load plugins!
+    for _, plugin in pairs(config.polish_plugins(plugins)) do
+      use(plugin)
     end
   end,
   config = {


### PR DESCRIPTION
This change allows users to manipulate the lua table passed to packer to
load plugins, allowing to override every aspect of the configuration.

Note that this is very low level and not suited to change plugin
configuration since there the configuration suggested by AstroVim is
lost at this point.

Fixes #113, Fixes #114

See the README.md change for an example on how to use this.