### PR TITLE
Make cmp more predictable and usable

### DIFF
--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -11,11 +11,6 @@ function M.config()
     return
   end
 
-  local check_backspace = function()
-    local col = vim.fn.col "." - 1
-    return col == 0 or vim.fn.getline("."):sub(col, col):match "%s"
-  end
-
   local kind_icons = {
     Text = "",
     Method = "",
@@ -45,6 +40,7 @@ function M.config()
   }
 
   cmp.setup {
+    preselect = cmp.PreselectMode.None,
     formatting = {
       fields = { "kind", "abbr", "menu" },
       format = function(_, vim_item)
@@ -95,16 +91,12 @@ function M.config()
         i = cmp.mapping.abort(),
         c = cmp.mapping.close(),
       },
-      ["<CR>"] = cmp.mapping.confirm { select = true },
+      ["<CR>"] = cmp.mapping.confirm(),
       ["<Tab>"] = cmp.mapping(function(fallback)
-        if cmp.visible() then
-          cmp.select_next_item()
-        elseif luasnip.expandable() then
+        if luasnip.expandable() then
           luasnip.expand()
         elseif luasnip.expand_or_jumpable() then
           luasnip.expand_or_jump()
-        elseif check_backspace() then
-          fallback()
         else
           fallback()
         end
@@ -113,9 +105,7 @@ function M.config()
         "s",
       }),
       ["<S-Tab>"] = cmp.mapping(function(fallback)
-        if cmp.visible() then
-          cmp.select_prev_item()
-        elseif luasnip.jumpable(-1) then
+        if luasnip.jumpable(-1) then
           luasnip.jump(-1)
         else
           fallback()


### PR DESCRIPTION
This commit does a few things to improve the usability of `cmp`

1. It does not auto select the first entry in the list. It must be specifically selected with ctrl-j/k or arrow keys. At the end of lines if I just want to type a new line and press enter and there is a possible selection it inserts it instead of a new line even though I did not select it.
2. Disabled the tab/s-tab for moving up and down in the list of completions. This is already enabled with ctrl-j/k and arrow keys and while the completion menu is open you can no longer jump between locations in a snippet without first pressing ctrl-e to close the menu.

Both of these issues cause behavior to change based on the menu being open and closed when interacting with the snippets and requires the user to think more before pressing keystrokes and whether or not they need to press `ctrl-e` first to close the menu.