### PR TITLE
Add arbitrary user configuration of default plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,28 @@ AstroVim is an aesthetic and feature-rich neovim config that is extensible and e
 </p>
 
 ## 🌟 Preview
+
 ![Preview1](./utils/media/preview1.png)
 ![Preview2](./utils/media/preview2.png)
 ![Preview33](./utils/media/preview3.png)
 
 ## ⚡ Requirements
-* [Nerd Fonts](https://www.nerdfonts.com/font-downloads)
-* [Neovim 0.6+](https://github.com/neovim/neovim/releases/tag/v0.6.1)
+
+- [Nerd Fonts](https://www.nerdfonts.com/font-downloads)
+- [Neovim 0.6+](https://github.com/neovim/neovim/releases/tag/v0.6.1)
 
 ## 🛠️ Installation
+
 ### Linux
+
 #### Make a backup of your current nvim folder
+
 ```
 mv ~/.config/nvim ~/.config/nvimbackup
 ```
+
 #### Clone the repository
+
 ```
 git clone https://github.com/kabinspace/AstroVim ~/.config/nvim
 nvim +PackerSync
@@ -92,7 +99,7 @@ plugins = {
       require("lsp_signature").setup()
     end,
   },
-},
+}
 
 -- Overrides
 overrides = {
@@ -149,7 +156,15 @@ Just copy the `packer` configuration without the `use` and with a `,` after the 
 
 See the example above.
 
-### Change Configfuration of default Plugins
+### Change Default Plugin Configurations
+
+AstroVim allows you to easily override the setup of any pre-configured plugins.
+Simply add a table to the `overrides` table with a key the same name as the
+plugin package and return a table with the new options or overrides that you
+want. For an example see the included `overrides` entry for `treesitter` which
+lets you extend the default treesitter configuration.
+
+### Change Default Packer Configuration
 
 AstroVim provides a `polish_plugins` function in the user settings that can be used to override the packer
 configuration for all plugins, user plugins as well as plugins configured by AstroVim.

--- a/lua/configs/autopairs.lua
+++ b/lua/configs/autopairs.lua
@@ -6,7 +6,7 @@ function M.config()
     return
   end
 
-  npairs.setup {
+  npairs.setup(require("core.utils").user_plugin_opts("nvim-autopairs", {
     check_ts = true,
     ts_config = {
       lua = { "string", "source" },
@@ -25,7 +25,7 @@ function M.config()
       highlight = "PmenuSel",
       highlight_grey = "LineNr",
     },
-  }
+  }))
 
   local cmp_autopairs = require "nvim-autopairs.completion.cmp"
   local cmp_status_ok, cmp = pcall(require, "cmp")

--- a/lua/configs/bufferline.lua
+++ b/lua/configs/bufferline.lua
@@ -6,7 +6,7 @@ function M.config()
     return
   end
 
-  bufferline.setup {
+  bufferline.setup(require("core.utils").user_plugin_opts("bufferline", {
     options = {
       offsets = {
         { filetype = "NvimTree", text = "", padding = 1 },
@@ -122,7 +122,7 @@ function M.config()
         guibg = { attribute = "bg", highlight = "BufferLineTabClose" },
       },
     },
-  }
+  }))
 end
 
 return M

--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -39,7 +39,7 @@ function M.config()
     TypeParameter = "",
   }
 
-  cmp.setup {
+  cmp.setup(require("core.utils").user_plugin_opts("cmp", {
     preselect = cmp.PreselectMode.None,
     formatting = {
       fields = { "kind", "abbr", "menu" },
@@ -115,7 +115,7 @@ function M.config()
         "s",
       }),
     },
-  }
+  }))
 end
 
 return M

--- a/lua/configs/comment.lua
+++ b/lua/configs/comment.lua
@@ -6,7 +6,7 @@ function M.config()
     return
   end
 
-  comment.setup {
+  comment.setup(require("core.utils").user_plugin_opts("Comment", {
     pre_hook = function(ctx)
       local U = require "Comment.utils"
 
@@ -22,7 +22,7 @@ function M.config()
         location = location,
       }
     end,
-  }
+  }))
 end
 
 return M

--- a/lua/configs/gitsigns.lua
+++ b/lua/configs/gitsigns.lua
@@ -6,7 +6,7 @@ function M.config()
     return
   end
 
-  gitsigns.setup {
+  gitsigns.setup(require("core.utils").user_plugin_opts("gitsigns", {
     signs = {
       add = { hl = "GitSignsAdd", text = "▎", numhl = "GitSignsAddNr", linehl = "GitSignsAddLn" },
       change = { hl = "GitSignsChange", text = "▎", numhl = "GitSignsChangeNr", linehl = "GitSignsChangeLn" },
@@ -57,7 +57,7 @@ function M.config()
     yadm = {
       enable = false,
     },
-  }
+  }))
 end
 
 return M

--- a/lua/configs/icons.lua
+++ b/lua/configs/icons.lua
@@ -37,7 +37,7 @@ function M.config()
     jpg = "#c882e7",
   }
 
-  icons.set_icon {
+  icons.set_icon(require("core.utils").user_plugin_opts("nvim-web-devicons", {
     c = {
       icon = "",
       color = colors.c,
@@ -183,7 +183,7 @@ function M.config()
       color = colors.jpeg,
       name = "jpeg",
     },
-  }
+  }))
 end
 
 return M

--- a/lua/configs/indent-line.lua
+++ b/lua/configs/indent-line.lua
@@ -51,10 +51,10 @@ function M.config()
     "operation_type",
   }
 
-  indent_blankline.setup {
+  indent_blankline.setup(require("core.utils").user_plugin_opts("indent_blankline", {
     show_current_context = true,
     show_current_context_start = false,
-  }
+  }))
 end
 
 return M

--- a/lua/configs/lsp/lspsaga.lua
+++ b/lua/configs/lsp/lspsaga.lua
@@ -6,7 +6,7 @@ function M.config()
     return
   end
 
-  lspsaga.setup {
+  lspsaga.setup(require("core.utils").user_plugin_opts("lspsaga", {
     debug = false,
     use_saga_diagnostic_sign = false,
     -- Diagnostics
@@ -47,7 +47,7 @@ function M.config()
     rename_prompt_prefix = "➤ ",
     server_filetype_map = {},
     diagnostic_prefix_format = "%d. ",
-  }
+  }))
 end
 
 return M

--- a/lua/configs/lualine.lua
+++ b/lua/configs/lualine.lua
@@ -237,7 +237,7 @@ function M.config()
     padding = { left = 1, right = 0 },
   }
 
-  lualine.setup(config)
+  lualine.setup(require("core.utils").user_plugin_opts("lualine", config))
 end
 
 return M

--- a/lua/configs/neoscroll.lua
+++ b/lua/configs/neoscroll.lua
@@ -6,7 +6,7 @@ function M.config()
     return
   end
 
-  neoscroll.setup {
+  neoscroll.setup(require("core.utils").user_plugin_opts("neoscroll", {
     -- All these keys will be mapped to their corresponding default scrolling animation
     mappings = { "<C-u>", "<C-d>", "<C-b>", "<C-f>", "<C-y>", "<C-e>", "zt", "zz", "zb" },
     hide_cursor = true, -- Hide cursor while scrolling
@@ -17,7 +17,7 @@ function M.config()
     easing_function = nil, -- Default easing function
     pre_hook = nil, -- Function to run before the scrolling animation starts
     post_hook = nil, -- Function to run after the scrolling animation ends
-  }
+  }))
 end
 
 return M

--- a/lua/configs/nvim-tree.lua
+++ b/lua/configs/nvim-tree.lua
@@ -32,7 +32,7 @@ function M.config()
     },
   }
 
-  nvimtree.setup {
+  nvimtree.setup(require("core.utils").user_plugin_opts("nvim-tree", {
     filters = {
       dotfiles = false,
       custom = {
@@ -91,7 +91,7 @@ function M.config()
       folder_arrows = 0,
       tree_width = 30,
     },
-  }
+  }))
 end
 
 return M

--- a/lua/configs/symbols-outline.lua
+++ b/lua/configs/symbols-outline.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.setup()
-  vim.g.symbols_outline = {
+  vim.g.symbols_outline = require("core.utils").user_plugin_opts("symbols_outline", {
     highlight_hovered_item = true,
     show_guides = true,
     auto_preview = true,
@@ -52,7 +52,7 @@ function M.setup()
       Operator = { icon = "+", hl = "TSOperator" },
       TypeParameter = { icon = "𝙏", hl = "TSParameter" },
     },
-  }
+  })
 end
 
 return M

--- a/lua/configs/telescope.lua
+++ b/lua/configs/telescope.lua
@@ -9,7 +9,7 @@ function M.config()
   local actions = require "telescope.actions"
   telescope.load_extension "fzf"
 
-  telescope.setup {
+  telescope.setup(require("core.utils").user_plugin_opts("telescope", {
     defaults = {
 
       prompt_prefix = " ",
@@ -103,7 +103,7 @@ function M.config()
         case_mode = "smart_case",
       },
     },
-  }
+  }))
 end
 
 return M

--- a/lua/configs/toggleterm.lua
+++ b/lua/configs/toggleterm.lua
@@ -6,7 +6,7 @@ function M.config()
     return
   end
 
-  toggleterm.setup {
+  toggleterm.setup(require("core.utils").user_plugin_opts("toggleterm", {
     size = 10,
     open_mapping = [[<c-\>]],
     hide_numbers = true,
@@ -27,7 +27,7 @@ function M.config()
         background = "Normal",
       },
     },
-  }
+  }))
 
   function _G.set_terminal_keymaps()
     local opts = { noremap = true }

--- a/lua/configs/treesitter.lua
+++ b/lua/configs/treesitter.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local config = require("core.utils").user_settings()
-
 function M.config()
   local status_ok, treesitter = pcall(require, "nvim-treesitter.configs")
   if not status_ok then
@@ -40,7 +38,7 @@ function M.config()
     },
   }
 
-  treesitter.setup(vim.tbl_deep_extend("force", {}, default_opts, config.overrides.treesitter))
+  treesitter.setup(require("core.utils").user_plugin_opts("treesitter", default_opts))
 end
 
 return M

--- a/lua/configs/which-key.lua
+++ b/lua/configs/which-key.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local user_settings = require("core.utils").user_settings()
-
 function M.config()
   local status_ok, which_key = pcall(require, "which-key")
   if not status_ok then
@@ -136,7 +134,7 @@ function M.config()
     },
   }
 
-  which_key.setup(vim.tbl_deep_extend("force", {}, default_setup, user_settings.overrides.which_key))
+  which_key.setup(require("core.utils").user_plugin_opts("which-key", default_setup))
   which_key.register(mappings, opts)
 end
 

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -47,6 +47,14 @@ function M.user_settings()
   return _user_settings
 end
 
+function M.user_plugin_opts(plugin, default)
+  local overrides = _user_settings.overrides[plugin]
+  if overrides ~= nil then
+    default = vim.tbl_deep_extend("force", default, overrides)
+  end
+  return default
+end
+
 function M.impatient()
   local impatient_ok, _ = pcall(require, "impatient")
   if impatient_ok then


### PR DESCRIPTION
This sets up a system that extends the `overrides` table in the user settings where the user can arbitrarily overwrite and extend any default plugin configuration files. 

Fixes #115, Fixes #112, Fixes #111