### PR TITLE
Lualine: Extract status functions

### DIFF
--- a/lua/configs/lualine.lua
+++ b/lua/configs/lualine.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local status = require "core.status"
+
 function M.config()
   local status_ok, lualine = pcall(require, "lualine")
   if not status_ok then
@@ -120,71 +122,14 @@ function M.config()
   }
 
   ins_right {
-    function(_)
-      local Lsp = vim.lsp.util.get_progress_messages()[1]
-
-      if Lsp then
-        local msg = Lsp.message or ""
-        local percentage = Lsp.percentage or 0
-        local title = Lsp.title or ""
-        local spinners = {
-          "",
-          "",
-          "",
-        }
-
-        local success_icon = {
-          "",
-          "",
-          "",
-        }
-
-        local ms = vim.loop.hrtime() / 1000000
-        local frame = math.floor(ms / 120) % #spinners
-
-        if percentage >= 70 then
-          return string.format(" %%<%s %s %s (%s%%%%) ", success_icon[frame + 1], title, msg, percentage)
-        end
-
-        return string.format(" %%<%s %s %s (%s%%%%) ", spinners[frame + 1], title, msg, percentage)
-      end
-
-      return ""
-    end,
+    status.lsp_progress,
     color = { gui = "none" },
     padding = { left = 0, right = 1 },
     cond = conditions.hide_in_width,
   }
 
   ins_right {
-    function(msg)
-      msg = msg or "Inactive"
-      local buf_clients = vim.lsp.buf_get_clients()
-      if next(buf_clients) == nil then
-        if type(msg) == "boolean" or #msg == 0 then
-          return "Inactive"
-        end
-        return msg
-      end
-      local buf_ft = vim.bo.filetype
-      local buf_client_names = {}
-
-      for _, client in pairs(buf_clients) do
-        if client.name ~= "null-ls" then
-          table.insert(buf_client_names, client.name)
-        end
-      end
-
-      local formatters = require "core.utils"
-      local supported_formatters = formatters.list_registered_formatters(buf_ft)
-      vim.list_extend(buf_client_names, supported_formatters)
-
-      local linters = require "core.utils"
-      local supported_linters = linters.list_registered_linters(buf_ft)
-      vim.list_extend(buf_client_names, supported_linters)
-
-      return table.concat(buf_client_names, ", ")
-    end,
+    status.lsp_name,
     icon = " ",
     color = { gui = "none" },
     padding = { left = 0, right = 1 },
@@ -192,13 +137,7 @@ function M.config()
   }
 
   ins_right {
-    function()
-      local b = vim.api.nvim_get_current_buf()
-      if next(vim.treesitter.highlighter.active[b]) then
-        return " 綠TS"
-      end
-      return ""
-    end,
+    status.treesitter_status,
     color = { fg = colors.green },
     padding = { left = 1, right = 0 },
     cond = conditions.hide_in_width,
@@ -216,14 +155,7 @@ function M.config()
   }
 
   ins_right {
-    function()
-      local current_line = vim.fn.line "."
-      local total_lines = vim.fn.line "$"
-      local chars = { "__", "▁▁", "▂▂", "▃▃", "▄▄", "▅▅", "▆▆", "▇▇", "██" }
-      local line_ratio = current_line / total_lines
-      local index = math.ceil(line_ratio * #chars)
-      return chars[index]
-    end,
+    status.progress_bar,
     padding = { left = 1, right = 1 },
     color = { fg = colors.yellow },
     cond = nil,

--- a/lua/core/status.lua
+++ b/lua/core/status.lua
@@ -1,0 +1,73 @@
+local M = {}
+
+function M.lsp_progress(_)
+  local Lsp = vim.lsp.util.get_progress_messages()[1]
+
+  if Lsp then
+    local msg = Lsp.message or ""
+    local percentage = Lsp.percentage or 0
+    local title = Lsp.title or ""
+
+    local spinners = { "", "", "" }
+    local success_icon = { "", "", "" }
+
+    local ms = vim.loop.hrtime() / 1000000
+    local frame = math.floor(ms / 120) % #spinners
+
+    if percentage >= 70 then
+      return string.format(" %%<%s %s %s (%s%%%%) ", success_icon[frame + 1], title, msg, percentage)
+    end
+
+    return string.format(" %%<%s %s %s (%s%%%%) ", spinners[frame + 1], title, msg, percentage)
+  end
+
+  return ""
+end
+
+function M.lsp_name(msg)
+  msg = msg or "Inactive"
+  local buf_clients = vim.lsp.buf_get_clients()
+  if next(buf_clients) == nil then
+    if type(msg) == "boolean" or #msg == 0 then
+      return "Inactive"
+    end
+    return msg
+  end
+  local buf_ft = vim.bo.filetype
+  local buf_client_names = {}
+
+  for _, client in pairs(buf_clients) do
+    if client.name ~= "null-ls" then
+      table.insert(buf_client_names, client.name)
+    end
+  end
+
+  local formatters = require "core.utils"
+  local supported_formatters = formatters.list_registered_formatters(buf_ft)
+  vim.list_extend(buf_client_names, supported_formatters)
+
+  local linters = require "core.utils"
+  local supported_linters = linters.list_registered_linters(buf_ft)
+  vim.list_extend(buf_client_names, supported_linters)
+
+  return table.concat(buf_client_names, ", ")
+end
+
+function M.treesitter_status()
+  local b = vim.api.nvim_get_current_buf()
+  if next(vim.treesitter.highlighter.active[b]) then
+    return " 綠TS"
+  end
+  return ""
+end
+
+function M.progress_bar()
+  local current_line = vim.fn.line "."
+  local total_lines = vim.fn.line "$"
+  local chars = { "__", "▁▁", "▂▂", "▃▃", "▄▄", "▅▅", "▆▆", "▇▇", "██" }
+  local line_ratio = current_line / total_lines
+  local index = math.ceil(line_ratio * #chars)
+  return chars[index]
+end
+
+return M


### PR DESCRIPTION
Extract the status functions from configs/lualine.lua into
core.status.lua.

This allows to reuse them in other places or with reconfigured lualines.