### PR TITLE
More extension for user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,14 @@ lets you extend the default treesitter configuration.
 
 ### Change Default Packer Configuration
 
-AstroVim provides a `polish_plugins` function in the user settings that can be used to override the packer
-configuration for all plugins, user plugins as well as plugins configured by AstroVim.
+The `overrides` table extensibility includes the packer configuration for all
+plugins, user plugins as well as plugins configured by AstroVim.
 
-E.g. this code in your `settings.lua` will globally disable the lazy loading that is used by AstroVim by default:
+E.g. this code in your `settings.lua` `overrides` table will globally disable the lazy loading that is used by AstroVim by default:
 
 ```lua
-  polish_plugins = function(plugins)
+overrides = {
+  plugins = function(plugins)
     local result = {}
     for _, plugin in pairs(plugins) do
       plugin["cmd"] = nil
@@ -180,7 +181,8 @@ E.g. this code in your `settings.lua` will globally disable the lazy loading tha
       table.insert(result, plugin)
     end
     return result
-  end
+  end,
+}
 ```
 
 ### Adding sources to `nvim-cmp`

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -350,7 +350,7 @@ local astro_plugins = {
 
 packer.startup {
   function(use)
-    local plugins = astro_plugins
+    local plugins = require("core.utils").user_plugin_opts("plugins", astro_plugins)
 
     -- Append user defined plugins
     if config.plugins and not vim.tbl_isempty(config.plugins) then

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -350,7 +350,7 @@ local astro_plugins = {
 
 packer.startup {
   function(use)
-    local plugins = require("core.utils").user_plugin_opts("plugins", astro_plugins)
+    local plugins = astro_plugins
 
     -- Append user defined plugins
     if config.plugins and not vim.tbl_isempty(config.plugins) then
@@ -360,7 +360,7 @@ packer.startup {
     end
 
     -- Load plugins!
-    for _, plugin in pairs(config.polish_plugins(plugins)) do
+    for _, plugin in pairs(require("core.utils").user_plugin_opts("plugins", plugins)) do
       use(plugin)
     end
   end,


### PR DESCRIPTION
This extends the user overrides a bit more. While maintaining the original API and no breaking changes

1. The user can define a `.lua` file in the `user` directory instead of in the `overrides` table and it will be treated as if it were in the overrides table where the filename is the key
2. instead of a table, the user can define a function that returns a table with a single parameter (i.e. `function(table)`) where the parameter passed in is the table that would be set and the function must return a table that will in turn  be set.

Example, if the user wants to override a `cmp` binding they can either put it in the `overrides` table in `settings.lua` using a function:

```lua
  overrides = {
    cmp = function(table)
      local status_ok, cmp = pcall(require, "cmp")
      if not status_ok then
        return table
      end

      table.mapping["<CR>"] = cmp.mapping.confirm { select = true }
      return table
    end,
  },
```

or they can specify a separate lua file `cmp.lua` in the user directory as a file that returns a table:

```lua
local status_ok, cmp = pcall(require, "cmp")
if not status_ok then
  return {}
end

return {
  mapping = {
    ["<CR>"] = cmp.mapping.confirm { status = true },
  },
}
```

or they can specify a separate lua file `cmp.lua` in the user directory as a file that returns a function:

```lua
return function(table)
  local status_ok, cmp = pcall(require, "cmp")
  if not status_ok then
    return table
  end

  table.mapping["<CR>"] = cmp.mapping.confirm { select = true }
  return table
end
```