### PR TITLE
Add keys to plugin table

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -10,27 +10,27 @@ local config = utils.user_settings()
 
 local astro_plugins = {
   -- Plugin manager
-  {
+  ["wbthomason/packer.nvim"] = {
     "wbthomason/packer.nvim",
   },
 
   -- Optimiser
-  {
+  ["lewis6991/impatient.nvim"] = {
     "lewis6991/impatient.nvim",
   },
 
   -- Lua functions
-  {
+  ["nvim-lua/plenary.nvim"] = {
     "nvim-lua/plenary.nvim",
   },
 
   -- Popup API
-  {
+  ["nvim-lua/popup.nvim"] = {
     "nvim-lua/popup.nvim",
   },
 
   -- Boost startup time
-  {
+  ["nathom/filetype.nvim"] = {
     "nathom/filetype.nvim",
     config = function()
       vim.g.did_load_filetypes = 1
@@ -38,7 +38,7 @@ local astro_plugins = {
   },
 
   -- Cursorhold fix
-  {
+  ["antoinemadec/FixCursorHold.nvim"] = {
     "antoinemadec/FixCursorHold.nvim",
     event = "BufRead",
     config = function()
@@ -47,7 +47,7 @@ local astro_plugins = {
   },
 
   -- Icons
-  {
+  ["kyazdani42/nvim-web-devicons"] = {
     "kyazdani42/nvim-web-devicons",
     config = function()
       require("configs.icons").config()
@@ -55,7 +55,7 @@ local astro_plugins = {
   },
 
   -- Bufferline
-  {
+  ["akinsho/bufferline.nvim"] = {
     "akinsho/bufferline.nvim",
     after = "nvim-web-devicons",
     config = function()
@@ -65,12 +65,12 @@ local astro_plugins = {
   },
 
   -- Better buffer closing
-  {
+  ["moll/vim-bbye"] = {
     "moll/vim-bbye",
   },
 
   -- File explorer
-  {
+  ["kyazdani42/nvim-tree.lua"] = {
     "kyazdani42/nvim-tree.lua",
     cmd = { "NvimTreeToggle", "NvimTreeFocus" },
     commit = "8b27fd4",
@@ -81,7 +81,7 @@ local astro_plugins = {
   },
 
   -- Statusline
-  {
+  ["nvim-lualine/lualine.nvim"] = {
     "nvim-lualine/lualine.nvim",
     commit = "6a3d367",
     config = function()
@@ -91,7 +91,7 @@ local astro_plugins = {
   },
 
   -- Syntax highlighting
-  {
+  ["nvim-treesitter/nvim-treesitter"] = {
     "nvim-treesitter/nvim-treesitter",
     run = ":TSUpdate",
     event = "BufRead",
@@ -130,7 +130,7 @@ local astro_plugins = {
   },
 
   -- Snippet engine
-  {
+  ["L3MON4D3/LuaSnip"] = {
     "L3MON4D3/LuaSnip",
     config = function()
       local settings = require("core.utils").user_settings()
@@ -145,7 +145,7 @@ local astro_plugins = {
   },
 
   -- Completion engine
-  {
+  ["hrsh7th/nvim-cmp"] = {
     "hrsh7th/nvim-cmp",
     event = "BufRead",
     config = function()
@@ -154,30 +154,30 @@ local astro_plugins = {
   },
 
   -- Snippet completion source
-  {
+  ["saadparwaiz1/cmp_luasnip"] = {
     "saadparwaiz1/cmp_luasnip",
     after = "nvim-cmp",
   },
 
   -- Buffer completion source
-  {
+  ["hrsh7th/cmp-buffer"] = {
     "hrsh7th/cmp-buffer",
     after = "nvim-cmp",
   },
 
   -- Path completion source
-  {
+  ["hrsh7th/cmp-path"] = {
     "hrsh7th/cmp-path",
     after = "nvim-cmp",
   },
 
   -- LSP completion source
-  {
+  ["hrsh7th/cmp-nvim-lsp"] = {
     "hrsh7th/cmp-nvim-lsp",
   },
 
   -- LSP manager
-  {
+  ["williamboman/nvim-lsp-installer"] = {
     "williamboman/nvim-lsp-installer",
     event = "BufRead",
     cmd = {
@@ -193,7 +193,7 @@ local astro_plugins = {
   },
 
   -- Built-in LSP
-  {
+  ["neovim/nvim-lspconfig"] = {
     "neovim/nvim-lspconfig",
     event = "BufRead",
     config = function()
@@ -202,7 +202,7 @@ local astro_plugins = {
   },
 
   -- LSP enhancer
-  {
+  ["tami5/lspsaga.nvim"] = {
     "tami5/lspsaga.nvim",
     event = "BufRead",
     config = function()
@@ -212,7 +212,7 @@ local astro_plugins = {
   },
 
   -- LSP symbols
-  {
+  ["simrat39/symbols-outline.nvim"] = {
     "simrat39/symbols-outline.nvim",
     cmd = "SymbolsOutline",
     setup = function()
@@ -222,7 +222,7 @@ local astro_plugins = {
   },
 
   -- Formatting and linting
-  {
+  ["jose-elias-alvarez/null-ls.nvim"] = {
     "jose-elias-alvarez/null-ls.nvim",
     event = "BufRead",
     config = function()
@@ -231,7 +231,7 @@ local astro_plugins = {
   },
 
   -- Fuzzy finder
-  {
+  ["nvim-telescope/telescope.nvim"] = {
     "nvim-telescope/telescope.nvim",
     cmd = "Telescope",
     config = function()
@@ -240,13 +240,13 @@ local astro_plugins = {
   },
 
   -- Fuzzy finder syntax support
-  {
+  ["nvim-telescope/telescope-fzf-native.nvim"] = {
     "nvim-telescope/telescope-fzf-native.nvim",
     run = "make",
   },
 
   -- Git integration
-  {
+  ["lewis6991/gitsigns.nvim"] = {
     "lewis6991/gitsigns.nvim",
     event = "BufRead",
     config = function()
@@ -256,7 +256,7 @@ local astro_plugins = {
   },
 
   -- Start screen
-  {
+  ["glepnir/dashboard-nvim"] = {
     "glepnir/dashboard-nvim",
     config = function()
       require("configs.dashboard").config()
@@ -265,7 +265,7 @@ local astro_plugins = {
   },
 
   -- Color highlighting
-  {
+  ["norcalli/nvim-colorizer.lua"] = {
     "norcalli/nvim-colorizer.lua",
     event = "BufRead",
     config = function()
@@ -275,7 +275,7 @@ local astro_plugins = {
   },
 
   -- Autopairs
-  {
+  ["windwp/nvim-autopairs"] = {
     "windwp/nvim-autopairs",
     event = "InsertEnter",
     config = function()
@@ -284,7 +284,7 @@ local astro_plugins = {
   },
 
   -- Terminal
-  {
+  ["akinsho/nvim-toggleterm.lua"] = {
     "akinsho/nvim-toggleterm.lua",
     cmd = "ToggleTerm",
     config = function()
@@ -294,7 +294,7 @@ local astro_plugins = {
   },
 
   -- Commenting
-  {
+  ["numToStr/Comment.nvim"] = {
     "numToStr/Comment.nvim",
     event = "BufRead",
     config = function()
@@ -304,7 +304,7 @@ local astro_plugins = {
   },
 
   -- Indentation
-  {
+  ["lukas-reineke/indent-blankline.nvim"] = {
     "lukas-reineke/indent-blankline.nvim",
     config = function()
       require("configs.indent-line").config()
@@ -313,7 +313,7 @@ local astro_plugins = {
   },
 
   -- Keymaps popup
-  {
+  ["folke/which-key.nvim"] = {
     "folke/which-key.nvim",
     config = function()
       require("configs.which-key").config()
@@ -322,7 +322,7 @@ local astro_plugins = {
   },
 
   -- Smooth scrolling
-  {
+  ["karb94/neoscroll.nvim"] = {
     "karb94/neoscroll.nvim",
     event = "BufRead",
     config = function()
@@ -332,7 +332,7 @@ local astro_plugins = {
   },
 
   -- Smooth escaping
-  {
+  ["max397574/better-escape.nvim"] = {
     "max397574/better-escape.nvim",
     event = { "InsertEnter" },
     config = function()
@@ -345,7 +345,7 @@ local astro_plugins = {
   },
 
   -- Get extra JSON schemas
-  { "b0o/SchemaStore.nvim" },
+  ["b0o/SchemaStore.nvim"] = { "b0o/SchemaStore.nvim" },
 }
 
 packer.startup {


### PR DESCRIPTION
This is a pretty simple change. It adds some ugliness to the `plugins.lua` table but is something the user will never have to really look at. Currently when overriding the plugins with a function if I want to disable lazy loading of a single plugin I have to do this:

```lua
function(plugins)
    local result = {}
    for _, plugin in pairs(plugins) do
      if plugin[1] == "akinsho/nvim-toggleterm.lua" then
        plugin["cmd"] = nil
      end
      table.insert(result, plugin)
    end
    return result
  end
```

This would allow the user to do something much simpler:

```lua
function(plugins)
  plugins["akinsho/nvim-toggleterm.lua"]["cmd"] = nil
  return plugins
end
```

This contains no breaking changes as these keys are not used internally at all and just provide a nice interface for the user if they want to override specific plugin configurations.