### PR TITLE
Unpin nvim-tree commit

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -73,7 +73,6 @@ local astro_plugins = {
   ["kyazdani42/nvim-tree.lua"] = {
     "kyazdani42/nvim-tree.lua",
     cmd = { "NvimTreeToggle", "NvimTreeFocus" },
-    commit = "8b27fd4",
     config = function()
       require("configs.nvim-tree").config()
     end,


### PR DESCRIPTION
I think nvim-tree has stabilized a bit. We can unpin the commit.

Fixes #121 