### PR TITLE
Remove dashboard statusline autocmd

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -24,7 +24,6 @@ if config.enabled.dashboard and config.enabled.bufferline then
       autocmd!
       autocmd FileType dashboard set showtabline=0
       autocmd BufWinLeave <buffer> set showtabline=2
-      autocmd BufEnter * if &ft is "dashboard" | set laststatus=0 | else | set laststatus=2 | endif
       autocmd BufEnter * if &ft is "dashboard" | set nocursorline | endif
     augroup end
   ]]


### PR DESCRIPTION
This is already taken care of with https://github.com/kabinspace/AstroVim/blob/db5e1523d27c3315e2e3632d6d0a14c8f6e704e4/lua/configs/dashboard.lua#L9

Fixes #140 