### PR TITLE
Add user configurability to better-escape

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -338,11 +338,11 @@ local astro_plugins = {
     "max397574/better-escape.nvim",
     event = { "InsertEnter" },
     config = function()
-      require("better_escape").setup {
+      require("better_escape").setup(utils.user_plugin_opts("better_escape", {
         mapping = { "ii", "jj", "jk", "kj" },
         timeout = vim.o.timeoutlen,
         keys = "<ESC>",
-      }
+      }))
     end,
   },
 


### PR DESCRIPTION
I noticed that there is a setup call with a config table for `better-escape`. This adds user configuration to:

```lua
overrides = {
  better_escape = {
  },
},
```