### PR TITLE
Make user config function more robust

### DIFF
--- a/lua/configs/colorizer.lua
+++ b/lua/configs/colorizer.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local user_plugin_opts = require("core.utils").user_plugin_opts
+
 function M.config()
   local present, colorizer = pcall(require, "colorizer")
   if not present then
@@ -7,8 +9,8 @@ function M.config()
   end
 
   colorizer.setup(
-    { "*" }, -- Highlight all files, but customize some others
-    {
+    user_plugin_opts("colorizer.filetype_opts", { "*" }), -- Highlight all files, but customize some others
+    user_plugin_opts("colorizer.default_opts", {
       RGB = true, -- #RGB hex codes
       RRGGBB = true, -- #RRGGBB hex codes
       names = false, -- "Name" codes like Blue
@@ -18,7 +20,7 @@ function M.config()
       css = false, -- Enable all css features: rgb_fn, hsl_fn, names, RGB, RRGGBB
       css_fn = false, -- Enable all CSS *functions*: rgb_fn, hsl_fn
       mode = "background", -- Set the display mode
-    }
+    })
   )
 end
 

--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -85,7 +85,7 @@ M.on_attach = function(client, bufnr)
     client.resolved_capabilities.document_formatting = false
   end
 
-  local on_attach_override = require("core.utils").user_settings().overrides.lsp_installer.on_attach_override
+  local on_attach_override = require("core.utils").user_plugin_opts "lsp_installer.on_attach_override"
   if on_attach_override ~= nil then
     on_attach_override(client, bufnr)
   end

--- a/lua/configs/lsp/lsp-installer.lua
+++ b/lua/configs/lsp/lsp-installer.lua
@@ -3,6 +3,8 @@ if not status_ok then
   return
 end
 
+local user_plugin_opts = require("core.utils").user_plugin_opts
+
 lsp_installer.on_server_ready(function(server)
   local opts = server:get_default_options()
   opts.on_attach = require("configs.lsp.handlers").on_attach
@@ -14,10 +16,12 @@ lsp_installer.on_server_ready(function(server)
     opts = vim.tbl_deep_extend("force", av_overrides, opts)
   end
 
-  local user, user_overrides = pcall(require, "user.server-settings." .. server.name)
-  if user then
-    opts = vim.tbl_deep_extend("force", user_overrides, opts)
-  end
+  opts = user_plugin_opts("server-settings." .. server.name, opts)
 
-  require("core.utils").user_settings().overrides.lsp_installer.server_registration_override(server, opts)
+  local user_override = user_plugin_opts "lsp_installer.server_registration_override"
+  if user_override ~= nil then
+    user_override(server, opts)
+  else
+    server:setup(opts)
+  end
 end)

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -5,18 +5,6 @@ local config = {
   plugins = {},
 
   overrides = {
-    lsp_installer = {
-      -- A function used to override how a LSP is registered
-      --
-      -- Gets the server object and the configuration as input and
-      -- will by default just call `server:setup(opts)`.
-      --
-      -- This function usually does not need to be overriden, only special
-      -- LSP integration plugins like `rust-tools.nvim` need this.
-      server_registration_override = function(server, opts)
-        server:setup(opts)
-      end,
-    },
     treesitter = {},
     luasnip = {
       -- A set of paths to look up VSCode snippets in

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -14,7 +14,11 @@ end
 local function load_user_settings(module, default)
   local overrides_status_ok, overrides = pcall(require, "user." .. module)
   if overrides_status_ok then
-    default = func_or_extend(overrides, default)
+    if default ~= nil then
+      default = func_or_extend(overrides, default)
+    else
+      default = overrides
+    end
   end
   return default
 end
@@ -56,9 +60,19 @@ function M.user_settings()
 end
 
 function M.user_plugin_opts(plugin, default)
-  local overrides = _user_settings.overrides[plugin]
+  local overrides = _user_settings.overrides
+  for tbl in string.gmatch(plugin, "([^%.]+)") do
+    overrides = overrides[tbl]
+    if overrides == nil then
+      break
+    end
+  end
   if overrides ~= nil then
-    default = func_or_extend(overrides, default)
+    if default ~= nil then
+      default = func_or_extend(overrides, default)
+    else
+      return overrides
+    end
   end
   return load_user_settings(plugin, default)
 end


### PR DESCRIPTION
This PR makes the user configuration more robust. Adds a few features:

- custom `server-settings` can now be put in the overrides table instead of just in files like this:

```lua
overrides = {
  ["server-settings"] = {
    yamlls = {
      settings = {
        yaml = {
          schemas = {
            ["http://json.schemastore.org/github-workflow"] = ".github/workflows/*.{yml,yaml}",
            ["http://json.schemastore.org/github-action"] = ".github/action.{yml,yaml}",
            ["http://json.schemastore.org/ansible-stable-2.9"] = "roles/tasks/*.{yml,yaml}",
          },
        },
      },
    },
  },
}
```

- stuff like the `lsp_installer` options for `on_attach_override` and `server_registration_override` can now be put into separate files instead of just in the `overrides` table under `user/lsp_installer/on_attach_override.lua` and `user/lsp_installer/server_registration_override` where each file just returns the new `on_attach` and `server_registration` functions.

- the colorizer is now configurable in the `overrides` table with

```lua
overrides = {
  colorizer = {
    filetype_opts = {},
    default_opts = {},
  },
},
```
or in the files `user/colorizer/filetype_opts.lua` and `user/colorizer/default_opts.lua`