### PR TITLE
Make telescope-fzf more stand-alone

### DIFF
--- a/lua/configs/telescope.lua
+++ b/lua/configs/telescope.lua
@@ -7,7 +7,6 @@ function M.config()
   end
 
   local actions = require "telescope.actions"
-  telescope.load_extension "fzf"
 
   telescope.setup(require("core.utils").user_plugin_opts("plugins.telescope", {
     defaults = {
@@ -95,14 +94,7 @@ function M.config()
       },
     },
     pickers = {},
-    extensions = {
-      fzf = {
-        fuzzy = true,
-        override_generic_sorter = true,
-        override_file_sorter = true,
-        case_mode = "smart_case",
-      },
-    },
+    extensions = {},
   }))
 end
 

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -252,7 +252,11 @@ local astro_plugins = {
   -- Fuzzy finder syntax support
   {
     "nvim-telescope/telescope-fzf-native.nvim",
+    after = "nvim-telescope/telescope.nvim",
     run = "make",
+    config = function()
+      require("telescope").load_extension "fzf"
+    end,
   },
 
   -- Git integration


### PR DESCRIPTION
The extension is the default anyway, so I just removed that...

This makes it possible to just disable the fzf plugin without killing the telescope plugin as well -- e.g. because you can not actually build the fzf binary this needs:-)