### PR TITLE
Allow user to override any entry in the default_theme

### DIFF
--- a/lua/default_theme/colors.lua
+++ b/lua/default_theme/colors.lua
@@ -40,4 +40,4 @@ local colors = {
   purple = "#c678dd",
 }
 
-return colors
+return require("core.utils").user_plugin_opts("default_theme.colors", colors)

--- a/lua/default_theme/init.lua
+++ b/lua/default_theme/init.lua
@@ -6,23 +6,25 @@ vim.o.background = "dark"
 vim.o.termguicolors = true
 vim.g.colors_name = "default_theme"
 
-C = require "default_theme.colors"
+local user_plugin_opts = require("core.utils").user_plugin_opts
 
 local util = require "default_theme.util"
-local base = require "default_theme.base"
-local treesitter = require "default_theme.treesitter"
-local lsp = require "default_theme.lsp"
-local others = require "default_theme.others"
 
-local default_theme = {
-  base,
-  treesitter,
-  lsp,
-  others,
+local modules = {
+  "base",
+  "treesitter",
+  "lsp",
+  "others",
 }
 
-for _, file in ipairs(default_theme) do
-  for group, colors in pairs(file) do
-    util.highlight(group, colors)
-  end
+local highlights = {}
+
+C = require "default_theme.colors"
+
+for _, module in ipairs(modules) do
+  highlights = vim.tbl_deep_extend("force", highlights, require("default_theme." .. module))
+end
+
+for group, colors in pairs(user_plugin_opts("default_theme.highlights", highlights)) do
+  util.highlight(group, colors)
 end

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -6,6 +6,17 @@ local config = {
   -- Default theme configuration
   default_theme = {
     diagnostics_style = "none",
+    -- Modify the color table
+    colors = {
+      fg = "#abb2bf",
+    },
+    -- Modify the highlight groups
+    highlights = function(highlights)
+      local C = require "default_theme.colors"
+
+      highlights.Normal = { fg = C.fg, bg = C.bg }
+      return highlights
+    end,
   },
 
   -- Disable default plugins


### PR DESCRIPTION
This allows the user to override colors and highlight groups inside of `init.lua`

example:

```lua
local config = {
  default_theme = {
    colors = {
      bg = "#1e222a",
    },
    highlights = {
      TSField = { fg = "#C9CBFF", style = "italic" },
    },
  }
}

return config
```

Example using the color table:

```lua
return {
  default_theme = {
    colors = {
      bg = "#1e222a",
      lavender = "#C9CBFF", -- add a new color
    },
    highlights = function(highlights)
      local C = require "default_theme.colors"
      highlights.TSField = { fg = C.lavender, style = "italic" }

      return highlights
    end,
  },
}
```