### PR TITLE
Add lazy-loading back to friendly-snippets

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -126,6 +126,7 @@ local astro_plugins = {
   -- Snippet collection
   {
     "rafamadriz/friendly-snippets",
+    event = "InsertEnter",
   },
 
   -- Snippet engine
@@ -138,6 +139,8 @@ local astro_plugins = {
       loader.lazy_load()
     end,
     wants = "friendly-snippets",
+    module = "luasnip",
+    event = "InsertEnter",
   },
 
   -- Completion engine


### PR DESCRIPTION
Fix lazy-loading snippets without breaking them like before #172 