### PR TITLE
Rebind save to ^s

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -126,7 +126,7 @@ if config.enabled.comment then
 end
 
 -- ForceWrite
-map("n", "<C-w>", "<cmd>w!<CR>", opts)
+map("n", "<C-s>", "<cmd>w!<CR>", opts)
 
 -- ForceQuit
 map("n", "<C-q>", "<cmd>q!<CR>", opts)


### PR DESCRIPTION
`^w` causes conflicts with the window bindings like `^ws` and `^wT` 

fixes #191 