### PR TITLE
remove conflicting rn binding

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -109,7 +109,7 @@ if config.enabled.lspsaga then
   map("n", "gl", "<cmd>Lspsaga show_line_diagnostics<CR>", opts)
   map("n", "ca", "<cmd>Lspsaga code_action<CR>", opts)
   map("n", "K", "<cmd>Lspsaga hover_doc<CR>", opts)
-  map("n", "rn", "<cmd>Lspsaga rename<CR>", opts)
+  map("n", "<leader>rn", "<cmd>Lspsaga rename<CR>", opts)
   map("n", "gj", "<cmd>Lspsaga diagnostic_jump_next<cr>", opts)
   map("n", "gk", "<cmd>Lspsaga diagnostic_jump_prev<cr>", opts)
   map("n", "<C-u>", "<cmd>lua require('lspsaga.action').smart_scroll_with_saga(-1)<cr>", opts)


### PR DESCRIPTION
Renaming is taken care of with the `<leader>lr` binding and `rn` conflicts with replacing a character with `n`