### PR TITLE
remove conflicting ca binding

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -107,7 +107,6 @@ map("n", "<leader>lD", "<cmd>Telescope diagnostics<CR>", opts)
 -- Lspsaga
 if config.enabled.lspsaga then
   map("n", "gl", "<cmd>Lspsaga show_line_diagnostics<CR>", opts)
-  map("n", "ca", "<cmd>Lspsaga code_action<CR>", opts)
   map("n", "K", "<cmd>Lspsaga hover_doc<CR>", opts)
   map("n", "rn", "<cmd>Lspsaga rename<CR>", opts)
   map("n", "gj", "<cmd>Lspsaga diagnostic_jump_next<cr>", opts)


### PR DESCRIPTION
Code action is taken care of with `<leader>la` and this conflicts with a very important part of the vim grammar. `ca<object>` for changing something like `ca[` for changing all of a `[]` surrounding area.