### PR TITLE
disable treesitter indentation module

### DIFF
--- a/lua/configs/treesitter.lua
+++ b/lua/configs/treesitter.lua
@@ -25,7 +25,7 @@ function M.config()
       enable = true,
     },
     indent = {
-      enable = true,
+      enable = false,
     },
     rainbow = {
       enable = true,


### PR DESCRIPTION
the Treesitter indent module is experimental (as said in their docs) and it was apparent specifically with Python. Disable it by default.

Fixes #199 