### PR TITLE
Add basic DAP support

### DIFF
--- a/lua/configs/dap.lua
+++ b/lua/configs/dap.lua
@@ -1,0 +1,32 @@
+local M = {}
+
+function M.ui_config()
+  local status_ok, dapui = pcall(require, "dapui")
+  if not status_ok then
+    return
+  end
+
+  dapui.setup(require("core.utils").user_plugin_opts("plugins.dapui", {}))
+
+  local dap = require "dap"
+  dap.listeners.after.event_initialized["dapui_config"] = function()
+    dapui.open()
+  end
+  dap.listeners.before.event_terminated["dapui_config"] = function()
+    dapui.close()
+  end
+  dap.listeners.before.event_exited["dapui_config"] = function()
+    dapui.close()
+  end
+end
+
+function M.install_config()
+  local status_ok, dap_install = pcall(require, "dap-install")
+  if not status_ok then
+    return
+  end
+
+  dap_install.setup(require("core.utils").user_plugin_opts("plugins.dap_install", {}))
+end
+
+return M

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -31,6 +31,7 @@ local config = {
     neoscroll = true,
     ts_rainbow = true,
     ts_autotag = true,
+    dap_support = false,
   },
 }
 

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -173,6 +173,20 @@ map("x", "<A-k>", "<cmd>move '<-2<CR>gv-gv", opts)
 -- disable Ex mode:
 map("n", "Q", "<Nop>", opts)
 
+-- DAP
+if config.enabled.dap_support then
+  map("n", "<F5>", ":lua require('dap').continue()<cr>", opts)
+  map("n", "<F10>", ":lua require('dap').step_over()<cr>", opts)
+  map("n", "<F11>", ":lua require('dap').step_into()<cr>", opts)
+  map("n", "<F12>", ":lua require('dap').step_out()<cr>", opts)
+  map("n", "<leader>bp", ":lua require('dap').toggle_breakpoint()<cr>", opts)
+  map("n", "<leader>Bp", ":lua require('dap').set_breakpoint(vim.fn.input('Breakpoint condition: '))<cr>", opts)
+  map("n", "<leader>lp", ":lua require('dap').set_breakpoint(nil, nil, vim.fn.input('Logpoint message: '))<cr>", opts)
+  map("n", "<leader>rp", ":lua require('dap').repl.open()<cr>", opts)
+  map("n", "<leader>RR", ":lua require('dap').run_last()<cr>", opts)
+  map("n", "<leader>XX", ":lua require('dap').terminate()<cr>", opts)
+end
+
 function _G.set_terminal_keymaps()
   vim.api.nvim_buf_set_keymap(0, "t", "<esc>", [[<C-\><C-n>]], opts)
   vim.api.nvim_buf_set_keymap(0, "t", "jk", [[<C-\><C-n>]], opts)

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -373,6 +373,27 @@ local astro_plugins = {
 
   -- Get extra JSON schemas
   { "b0o/SchemaStore.nvim" },
+
+  -- DAP:
+  {
+    "mfussenegger/nvim-dap",
+    disable = not config.enabled.dap_support,
+  },
+  {
+    "rcarriga/nvim-dap-ui",
+    requires = { "nvim-dap", "rust-tools.nvim" },
+    config = function()
+      require("configs.dap").ui_config()
+    end,
+    disable = not config.enabled.dap_support,
+  },
+  {
+    "Pocco81/DAPInstall.nvim",
+    config = function()
+      require("configs.dap").install_config()
+    end,
+    disable = not config.enabled.dap_support,
+  },
 }
 
 packer.startup {


### PR DESCRIPTION
DAP is awfully handy to debug some things, especially with language support extensions that hook into this generic DAP support (e.g. rust-tools.nvim).

With this configuration + rust-tools I can hit "K" on a main function, select "debug" in the hover popup and have the DAP UI come up after a while;-)