### PR TITLE
Move polish function to truly running last

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -23,11 +23,9 @@ for _, source in ipairs(sources) do
   end
 end
 
-local polish = utils.user_plugin_opts "polish"
+utils.compiled()
 
+local polish = utils.user_plugin_opts "polish"
 if type(polish) == "function" then
   polish()
 end
-
--- keep this last:
-utils.compiled()


### PR DESCRIPTION
Compiled packer configs run after the polish function, we should change this ordering.

Resolves #228 