### PR TITLE
Add tab selection for cmp

### DIFF
--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -11,11 +11,6 @@ function M.config()
     return
   end
 
-  local check_backspace = function()
-    local col = vim.fn.col "." - 1
-    return col == 0 or vim.fn.getline("."):sub(col, col):match "%s"
-  end
-
   local kind_icons = {
     Text = "",
     Method = "",
@@ -104,8 +99,6 @@ function M.config()
           luasnip.expand()
         elseif luasnip.expand_or_jumpable() then
           luasnip.expand_or_jump()
-        elseif check_backspace() then
-          fallback()
         else
           fallback()
         end

--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -11,6 +11,11 @@ function M.config()
     return
   end
 
+  local check_backspace = function()
+    local col = vim.fn.col "." - 1
+    return col == 0 or vim.fn.getline("."):sub(col, col):match "%s"
+  end
+
   local kind_icons = {
     Text = "",
     Method = "",
@@ -91,12 +96,16 @@ function M.config()
         i = cmp.mapping.abort(),
         c = cmp.mapping.close(),
       },
-      ["<CR>"] = cmp.mapping.confirm(),
+      ["<CR>"] = cmp.mapping.confirm { select = true },
       ["<Tab>"] = cmp.mapping(function(fallback)
-        if luasnip.expandable() then
+        if cmp.visible() then
+          cmp.select_next_item()
+        elseif luasnip.expandable() then
           luasnip.expand()
         elseif luasnip.expand_or_jumpable() then
           luasnip.expand_or_jump()
+        elseif check_backspace() then
+          fallback()
         else
           fallback()
         end
@@ -105,7 +114,9 @@ function M.config()
         "s",
       }),
       ["<S-Tab>"] = cmp.mapping(function(fallback)
-        if luasnip.jumpable(-1) then
+        if cmp.visible() then
+          cmp.select_prev_item()
+        elseif luasnip.jumpable(-1) then
           luasnip.jump(-1)
         else
           fallback()

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -161,7 +161,6 @@ map("v", ">", ">gv", opts)
 -- Move text up and down
 map("v", "<A-j>", "<cmd>m .+1<CR>==", opts)
 map("v", "<A-k>", "<cmd>m .-2<CR>==", opts)
-map("v", "p", '"_dP', opts)
 
 -- Visual Block --
 -- Move text up and down


### PR DESCRIPTION
Adds back tab completion to CMP and fixed `p` when navigating snippets


Fixes #230 