### PR TITLE
Make filetype easily user extended

### DIFF
--- a/lua/configs/filetype.lua
+++ b/lua/configs/filetype.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+function M.config()
+  local present, better_escape = pcall(require, "filetype")
+  if not present then
+    return
+  end
+
+  if vim.fn.has "nvim-0.6" == 0 then
+    vim.g.did_load_filetypes = 1
+  end
+
+  better_escape.setup(require("core.utils").user_plugin_opts("plugins.filetype", {}))
+end
+
+return M

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -27,7 +27,7 @@ local astro_plugins = {
   {
     "nathom/filetype.nvim",
     config = function()
-      vim.g.did_load_filetypes = 1
+      require("configs.filetype").config()
     end,
   },
 


### PR DESCRIPTION
This allows the user to easily extend the `filetype.nvim` setup