### PR TITLE
Disable diagnostics on neotree

### DIFF
--- a/lua/configs/neo-tree.lua
+++ b/lua/configs/neo-tree.lua
@@ -16,7 +16,7 @@ function M.config()
     close_if_last_window = true,
     popup_border_style = "rounded",
     enable_git_status = true,
-    enable_diagnostics = true,
+    enable_diagnostics = false,
     default_component_configs = {
       indent = {
         indent_size = 2,
@@ -86,8 +86,8 @@ function M.config()
     filesystem = {
       filtered_items = {
         visible = false,
-        hide_dotfiles = true,
-        hide_gitignored = true,
+        hide_dotfiles = false,
+        hide_gitignored = false,
         hide_by_name = {
           ".DS_Store",
           "thumbs.db",
@@ -119,6 +119,16 @@ function M.config()
           ["gp"] = "git_push",
           ["gg"] = "git_commit_and_push",
         },
+      },
+    },
+    event_handlers = {
+      {
+        event = "vim_buffer_enter",
+        handler = function(_)
+          if vim.bo.filetype == "neo-tree" then
+            vim.wo.signcolumn = "auto"
+          end
+        end,
       },
     },
   }))

--- a/lua/default_theme/colors.lua
+++ b/lua/default_theme/colors.lua
@@ -13,6 +13,7 @@ local colors = {
   blue = "#61afef",
   blue_1 = "#40d9ff",
   blue_2 = "#1b1f27",
+  blue_3 = "#8094B4",
   orange = "#d19a66",
   orange_1 = "#ff9640",
   orange_2 = "#ff8800",

--- a/lua/default_theme/others.lua
+++ b/lua/default_theme/others.lua
@@ -123,8 +123,11 @@ local others = {
 
   -- Neo-Tree
   NeoTreeDirectoryIcon = { fg = C.blue },
+  NeoTreeRootName = { fg = C.fg, style = "bold" },
+  NeoTreeFileName = { fg = C.fg },
+  NeoTreeFileIcon = { fg = C.fg },
   NeoTreeFileNameOpened = { fg = C.green },
-  NeoTreeIndentMarker = { fg = C.grey_6 },
+  NeoTreeIndentMarker = { fg = C.blue_3 },
   NeoTreeGitAdded = { fg = C.green },
   NeoTreeGitConflict = { fg = C.red },
   NeoTreeGitModified = { fg = C.orange },


### PR DESCRIPTION
- Change highlight groups
- Disable diagnostics
- Disable signcolumn
- Show git ignored and dot files