### PR TITLE
Fix hiding dotfiles but maintaining that they show by default

### DIFF
--- a/lua/configs/neo-tree.lua
+++ b/lua/configs/neo-tree.lua
@@ -85,8 +85,8 @@ function M.config()
     nesting_rules = {},
     filesystem = {
       filtered_items = {
-        visible = false,
-        hide_dotfiles = false,
+        visible = true,
+        hide_dotfiles = true,
         hide_gitignored = false,
         hide_by_name = {
           ".DS_Store",


### PR DESCRIPTION
Before this commit it becomes actually impossible to hide the dotfiles in the tree so the toggle visibility function becomes useless 😂 