### PR TITLE
fix hidden files in neo-tree

### DIFF
--- a/lua/configs/neo-tree.lua
+++ b/lua/configs/neo-tree.lua
@@ -86,7 +86,7 @@ function M.config()
     filesystem = {
       filtered_items = {
         visible = false,
-        hide_dotfiles = false,
+        hide_dotfiles = true,
         hide_gitignored = false,
         hide_by_name = {
           ".DS_Store",


### PR DESCRIPTION
This makes hidden files (dotfiles) actually hidden by default just like every other file manager as well as the default telescope search.