### PR TITLE
improve cmp lazy loading

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -153,7 +153,7 @@ local astro_plugins = {
   -- Snippet collection
   {
     "rafamadriz/friendly-snippets",
-    event = "InsertEnter",
+    after = "nvim-cmp",
   },
 
   -- Snippet engine
@@ -168,7 +168,7 @@ local astro_plugins = {
   -- Completion engine
   {
     "hrsh7th/nvim-cmp",
-    event = "BufWinEnter",
+    event = "InsertEnter",
     config = function()
       require("configs.cmp").config()
     end,
@@ -217,7 +217,7 @@ local astro_plugins = {
   -- Built-in LSP
   {
     "neovim/nvim-lspconfig",
-    after = "cmp-nvim-lsp",
+    event = "BufWinEnter",
     config = function()
       require "configs.lsp"
     end,


### PR DESCRIPTION
Makes `cmp` load on InsertEnter instead of BufWinEnter. We need to make sure it doesn't bring back the problems that #236 solved. (We need to make sure rust LSP starts when selecting from neo-tree still.