### PR TITLE
Move from dressing to NUI vim ui

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -23,6 +23,15 @@ for _, source in ipairs(sources) do
   end
 end
 
+local status_ok, ui = pcall(require, "core.ui")
+if status_ok then
+  for ui_addition, enabled in pairs(utils.user_settings().ui) do
+    if enabled and type(ui[ui_addition]) == "function" then
+      ui[ui_addition]()
+    end
+  end
+end
+
 utils.compiled()
 
 local polish = utils.user_plugin_opts "polish"

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -32,6 +32,11 @@ local config = {
     ts_rainbow = true,
     ts_autotag = true,
   },
+
+  ui = {
+    nui_input = true,
+    telescope_select = true,
+  },
 }
 
 return config

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -41,11 +41,8 @@ local astro_plugins = {
 
   -- Neovim UI Enhancer
   {
-    "stevearc/dressing.nvim",
-    event = "BufWinEnter",
-    config = function()
-      require("configs.dressing").config()
-    end,
+    "MunifTanjim/nui.nvim",
+    module = "nui",
   },
 
   -- Cursorhold fix

--- a/lua/core/ui.lua
+++ b/lua/core/ui.lua
@@ -1,0 +1,134 @@
+local M = {}
+function M.nui_input()
+  -- Set up NUI for UI Input
+  -- From: https://github.com/MunifTanjim/nui.nvim/wiki/vim.ui#vimuiinput
+  local input_ui
+  vim.ui.input = function(opts, on_confirm)
+    local Input = require "nui.input"
+    local event = require("nui.utils.autocmd").event
+    if input_ui then
+      -- ensure single ui.input operation
+      vim.api.nvim_err_writeln "busy: another input is pending!"
+      return
+    end
+
+    local function on_done(value)
+      if input_ui then
+        -- if it's still mounted, unmount it
+        input_ui:unmount()
+      end
+      -- pass the input value
+      on_confirm(value)
+      -- indicate the operation is done
+      input_ui = nil
+    end
+
+    local border_top_text = opts.prompt or "[Input]"
+    local default_value = opts.default
+
+    input_ui = Input({
+      relative = "cursor",
+      position = {
+        row = 1,
+        col = 0,
+      },
+      size = {
+        -- minimum width 20
+        width = math.max(20, type(default_value) == "string" and #default_value or 0),
+      },
+      border = {
+        style = "rounded",
+        highlight = "Normal",
+        text = {
+          top = border_top_text,
+          top_align = "left",
+        },
+      },
+      win_options = {
+        winhighlight = "Normal:Normal",
+      },
+    }, {
+      default_value = default_value,
+      on_close = function()
+        on_done(nil)
+      end,
+      on_submit = function(value)
+        on_done(value)
+      end,
+    })
+
+    input_ui:mount()
+
+    -- cancel operation if cursor leaves input
+    input_ui:on(event.BufLeave, function()
+      on_done(nil)
+    end, { once = true })
+
+    -- cancel operation if <Esc> is pressed
+    input_ui:map("n", "<Esc>", function()
+      on_done(nil)
+    end, { noremap = true, nowait = true })
+  end
+end
+
+function M.telescope_select()
+  -- Telescope UI selection
+  -- From: https://github.com/stevearc/dressing.nvim/blob/master/lua/dressing/select/telescope.lua
+  vim.ui.select = function(items, opts, on_choice)
+    local themes = require "telescope.themes"
+    local actions = require "telescope.actions"
+    local state = require "telescope.actions.state"
+    local pickers = require "telescope.pickers"
+    local finders = require "telescope.finders"
+    local conf = require("telescope.config").values
+
+    local entry_maker = function(item)
+      local formatted = opts.format_item(item)
+      return {
+        display = formatted,
+        ordinal = formatted,
+        value = item,
+      }
+    end
+
+    local picker_opts = themes.get_dropdown()
+
+    pickers.new(picker_opts, {
+      prompt_title = opts.prompt,
+      previewer = false,
+      finder = finders.new_table {
+        results = items,
+        entry_maker = entry_maker,
+      },
+      sorter = conf.generic_sorter(opts),
+      attach_mappings = function(prompt_bufnr)
+        actions.select_default:replace(function()
+          local selection = state.get_selected_entry()
+          actions._close(prompt_bufnr, false)
+          if not selection then
+            -- User did not select anything.
+            on_choice(nil, nil)
+            return
+          end
+          local idx = nil
+          for i, item in ipairs(items) do
+            if item == selection.value then
+              idx = i
+              break
+            end
+          end
+          on_choice(selection.value, idx)
+        end)
+
+        actions.close:replace(function()
+          actions._close(prompt_bufnr, false)
+          on_choice(nil, nil)
+        end)
+
+        return true
+      end,
+    }):find()
+  end
+end
+
+return M

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -37,6 +37,12 @@ local config = {
     ts_autotag = true,
   },
 
+  -- Disable AstroVim ui features
+  ui = {
+    nui_input = true,
+    telescope_select = true,
+  },
+
   -- Configure plugins
   plugins = {
     -- Add plugins, the packer syntax without the "use"


### PR DESCRIPTION
Now that we are using `neo-tree` we need to use `nui.nvim`. With that being the case it doesn't make sense to include 2 plugins that improve the neovim user interface. This replaces dressing nvim stuff with just nui. After doing some testing I have also found that this geatly increases load time because we can easily still lazy load both `nui` and `telescope`. Also `nui` is faster than `dressing`.

This does include wrapping up our own vim ui functions instead of using plugins, but this allows us to have users toggle either one or both of the features off depending on what plugins they like using while also letting us lazy load nicely.