### PR TITLE
Make packer work with rebases

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -392,6 +392,9 @@ packer.startup {
     },
     git = {
       clone_timeout = 300,
+      subcommands = {
+        update = "pull --ff-only --progress --rebase=true",
+      },
     },
     auto_clean = true,
     compile_on_sync = true,


### PR DESCRIPTION
This fixes things when rebases happen on plugins. This does mess up right  now viewing the commit changes when a plugin was rebased.

Hopefully this gets resolved upstream at some point: https://github.com/wbthomason/packer.nvim/issues/381, https://github.com/wbthomason/packer.nvim/issues/760