### PR TITLE
Remove duplicated diagnostic sign definition (LSP)

### DIFF
--- a/lua/configs/filetype.lua
+++ b/lua/configs/filetype.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.config()
-  local present, better_escape = pcall(require, "filetype")
+  local present, filetype = pcall(require, "filetype")
   if not present then
     return
   end
@@ -10,7 +10,7 @@ function M.config()
     vim.g.did_load_filetypes = 1
   end
 
-  better_escape.setup(require("core.utils").user_plugin_opts("plugins.filetype", {}))
+  filetype.setup(require("core.utils").user_plugin_opts("plugins.filetype", {}))
 end
 
 return M

--- a/lua/configs/neo-tree.lua
+++ b/lua/configs/neo-tree.lua
@@ -7,10 +7,6 @@ function M.config()
   end
 
   vim.g.neo_tree_legacy_commands = 1
-  vim.fn.sign_define("DiagnosticSignError", { text = "", texthl = "DiagnosticSignError" })
-  vim.fn.sign_define("DiagnosticSignWarn", { text = "", texthl = "DiagnosticSignWarn" })
-  vim.fn.sign_define("DiagnosticSignInfo", { text = "", texthl = "DiagnosticSignInfo" })
-  vim.fn.sign_define("DiagnosticSignHint", { text = "", texthl = "DiagnosticSignHint" })
 
   neotree.setup(require("core.utils").user_plugin_opts("plugins.neo-tree", {
     close_if_last_window = true,


### PR DESCRIPTION
I just discovered that the diagnostic signs are already defined here:

https://github.com/kabinspace/AstroVim/blob/187c756f7f1c5168e3ba88a2ce55f71837378ab6/lua/configs/lsp/handlers.lua#L4-L9

So I removed those from the Neo-tree config as we don't really need to redefine them again.

Also corrected a small typo in the filetype config. 🙂