### PR TITLE
Move binding setting to which-key for easier user override in config

### DIFF
--- a/lua/configs/which-key-register.lua
+++ b/lua/configs/which-key-register.lua
@@ -17,27 +17,27 @@ local opts = {
 }
 
 local mappings = {
-  ["w"] = { "Save" },
-  ["q"] = { "Quit" },
-  ["h"] = { "No Highlight" },
+  ["w"] = { "<cmd>w<CR>", "Save" },
+  ["q"] = { "<cmd>q<CR>", "Quit" },
+  ["h"] = { "<cmd>nohlsearch<CR>", "No Highlight" },
 
   p = {
     name = "Packer",
-    c = { "Compile" },
-    i = { "Install" },
-    s = { "Sync" },
-    S = { "Status" },
-    u = { "Update" },
+    c = { "<cmd>PackerCompile<cr>", "Compile" },
+    i = { "<cmd>PackerInstall<cr>", "Install" },
+    s = { "<cmd>PackerSync<cr>", "Sync" },
+    S = { "<cmd>PackerStatus<cr>", "Status" },
+    u = { "<cmd>PackerUpdate<cr>", "Update" },
   },
 
   l = {
     name = "LSP",
-    a = { "Code Action" },
-    d = { "Hover Diagnostic" },
-    f = { "Format" },
-    i = { "Info" },
-    I = { "Installer Info" },
-    r = { "Rename" },
+    a = { "<cmd>lua vim.lsp.buf.code_action()<CR>", "Code Action" },
+    d = { "<cmd>lua vim.diagnostic.open_float()<CR>", "Hover Diagnostic" },
+    f = { "<cmd>lua vim.lsp.buf.formatting_sync()<cr>", "Format" },
+    i = { "<cmd>LspInfo<cr>", "Info" },
+    I = { "<cmd>LspInstallInfo<cr>", "Installer Info" },
+    r = { "<cmd>lua vim.lsp.buf.rename()<CR>", "Rename" },
   },
 }
 
@@ -57,95 +57,89 @@ local function init_table(idx)
 end
 
 if utils.is_available "neo-tree.nvim" then
-  mappings.e = { "Toggle Explorer" }
-  mappings.o = { "Focus Explorer" }
+  mappings.e = { "<cmd>Neotree toggle<CR>", "Toggle Explorer" }
+  mappings.o = { "<cmd>Neotree focus<CR>", "Focus Explorer" }
 end
 
 if utils.is_available "dashboard-nvim" then
-  mappings.d = { "Dashboard" }
+  mappings.d = { "<cmd>Dashboard<CR>", "Dashboard" }
 
   init_table "f"
-  mappings.f.n = { "New File" }
+  mappings.f.n = { "<cmd>DashboardNewFile<CR>", "New File" }
 
   init_table "S"
-  mappings.S.s = { "Save Session" }
-  mappings.S.l = { "Load Session" }
+  mappings.S.s = { "<cmd>SessionLoad<CR>", "Save Session" }
+  mappings.S.l = { "<cmd>SessionSave<CR>", "Load Session" }
 end
 
 if utils.is_available "Comment.nvim" then
-  mappings["/"] = { "Comment" }
+  mappings["/"] = { "<cmd>lua require('Comment.api').toggle_current_linewise()<cr>", "Comment" }
 end
 
 if utils.is_available "vim-bbye" then
-  mappings.c = { "Close Buffer" }
+  mappings.c = { "<cmd>Bdelete!<CR>", "Close Buffer" }
 end
 
 if utils.is_available "gitsigns.nvim" then
   init_table "g"
-  mappings.g.j = { "Next Hunk" }
-  mappings.g.k = { "Prev Hunk" }
-  mappings.g.l = { "Blame" }
-  mappings.g.p = { "Preview Hunk" }
-  mappings.g.h = { "Reset Hunk" }
-  mappings.g.r = { "Reset Buffer" }
-  mappings.g.s = { "Stage Hunk" }
-  mappings.g.u = { "Undo Stage Hunk" }
-  mappings.g.d = { "Diff" }
-end
-
-if utils.is_available "gitsigns.nvim" then
-  init_table "g"
-  mappings.g.t = { "Open changed file" }
-  mappings.g.b = { "Checkout branch" }
-  mappings.g.c = { "Checkout commit" }
+  mappings.g.j = { "<cmd>lua require 'gitsigns'.next_hunk()<cr>", "Next Hunk" }
+  mappings.g.k = { "<cmd>lua require 'gitsigns'.prev_hunk()<cr>", "Prev Hunk" }
+  mappings.g.l = { "<cmd>lua require 'gitsigns'.blame_line()<cr>", "Blame" }
+  mappings.g.p = { "<cmd>lua require 'gitsigns'.preview_hunk()<cr>", "Preview Hunk" }
+  mappings.g.h = { "<cmd>lua require 'gitsigns'.reset_hunk()<cr>", "Reset Hunk" }
+  mappings.g.r = { "<cmd>lua require 'gitsigns'.reset_buffer()<cr>", "Reset Buffer" }
+  mappings.g.s = { "<cmd>lua require 'gitsigns'.stage_hunk()<cr>", "Stage Hunk" }
+  mappings.g.u = { "<cmd>lua require 'gitsigns'.undo_stage_hunk()<cr>", "Undo Stage Hunk" }
+  mappings.g.d = { "<cmd>lua require 'gitsigns'.diffthis()<cr>", "Diff" }
 end
 
 if utils.is_available "nvim-toggleterm.lua" then
   init_table "g"
-  mappings.g.g = { "Lazygit" }
+  mappings.g.g = { "<cmd>lua require('core.utils').toggle_term_cmd('lazygit')<CR>", "Lazygit" }
 
   init_table "t"
-  mappings.t.n = { "Node" }
-  mappings.t.u = { "NCDU" }
-  mappings.t.t = { "Htop" }
-  mappings.t.p = { "Python" }
-  mappings.t.f = { "Float" }
-  mappings.t.h = { "Horizontal" }
-  mappings.t.v = { "Vertical" }
+  mappings.t.n = { "<cmd>lua require('core.utils').toggle_term_cmd('node')<CR>", "Node" }
+  mappings.t.u = { "<cmd>lua require('core.utils').toggle_term_cmd('ncdu')<CR>", "NCDU" }
+  mappings.t.t = { "<cmd>lua require('core.utils').toggle_term_cmd('htop')<CR>", "Htop" }
+  mappings.t.p = { "<cmd>lua require('core.utils').toggle_term_cmd('python')<CR>", "Python" }
+  mappings.t.l = { "<cmd>lua require('core.utils').toggle_term_cmd('lazygit')<CR>", "Lazygit" }
+  mappings.t.f = { "<cmd>ToggleTerm direction=float<cr>", "Float" }
+  mappings.t.h = { "<cmd>ToggleTerm size=10 direction=horizontal<cr>", "Horizontal" }
+  mappings.t.v = { "<cmd>ToggleTerm size=80 direction=vertical<cr>", "Vertical" }
 end
 
 if utils.is_available "symbols-outline.nvim" then
   init_table "l"
-  mappings.l.S = { "Symbols Outline" }
+  mappings.l.S = { "<cmd>SymbolsOutline<CR>", "Symbols Outline" }
 end
 
 if utils.is_available "telescope.nvim" then
   init_table "s"
-  mappings.s.b = { "Checkout branch" }
-  mappings.s.h = { "Find Help" }
-  mappings.s.m = { "Man Pages" }
-  mappings.s.n = { "Notifications" }
-  mappings.s.r = { "Registers" }
-  mappings.s.k = { "Keymaps" }
-  mappings.s.c = { "Commands" }
+  mappings.s.b = { "<cmd>Telescope git_branches<CR>", "Checkout branch" }
+  mappings.s.h = { "<cmd>Telescope help_tags<CR>", "Find Help" }
+  mappings.s.m = { "<cmd>Telescope man_pages<CR>", "Man Pages" }
+  mappings.s.n = { "<cmd>Telescope notify<CR>", "Notifications" }
+  mappings.s.r = { "<cmd>Telescope registers<CR>", "Registers" }
+  mappings.s.k = { "<cmd>Telescope keymaps<CR>", "Keymaps" }
+  mappings.s.c = { "<cmd>Telescope commands<CR>", "Commands" }
 
   init_table "g"
-  mappings.g.t = { "Open changed file" }
-  mappings.g.b = { "Checkout branch" }
-  mappings.g.c = { "Checkout commit" }
+  mappings.g.t = { "<cmd>Telescope git_status<CR>", "Open changed file" }
+  mappings.g.b = { "<cmd>Telescope git_branches<CR>", "Checkout branch" }
+  mappings.g.c = { "<cmd>Telescope git_commits<CR>", "Checkout commit" }
 
   init_table "f"
-  mappings.f.b = { "Find Buffers" }
-  mappings.f.f = { "Find Files" }
-  mappings.f.h = { "Find Help" }
-  mappings.f.m = { "Find Marks" }
-  mappings.f.o = { "Find Old Files" }
-  mappings.f.w = { "Find Words" }
+  mappings.f.b = { "<cmd>Telescope buffers<CR>", "Find Buffers" }
+  mappings.f.f = { "<cmd>Telescope find_files<CR>", "Find Files" }
+  mappings.f.h = { "<cmd>Telescope help_tags<CR>", "Find Help" }
+  mappings.f.m = { "<cmd>Telescope marks<CR>", "Find Marks" }
+  mappings.f.o = { "<cmd>Telescope oldfiles<CR>", "Find Old Files" }
+  mappings.f.w = { "<cmd>Telescope live_grep<CR>", "Find Words" }
 
   init_table "l"
-  mappings.l.s = { "Document Symbols" }
-  mappings.l.R = { "References" }
-  mappings.l.D = { "All Diagnostics" }
+  mappings.l.s = { "<cmd>Telescope lsp_document_symbols<CR>", "Document Symbols" }
+  mappings.l.R = { "<cmd>Telescope lsp_references<CR>", "References" }
+  mappings.l.D = { "<cmd>Telescope diagnostics<CR>", "All Diagnostics" }
 end
 
 which_key.register(require("core.utils").user_plugin_opts("which-key.register_n_leader", mappings), opts)

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -40,77 +40,6 @@ end
 map("n", "<A-j>", "<Esc><cmd>m .+1<CR>==gi", opts)
 map("n", "<A-k>", "<Esc><cmd>m .-2<CR>==gi", opts)
 
--- Standard Operations
-map("n", "<leader>w", "<cmd>w<CR>", opts)
-map("n", "<leader>q", "<cmd>q<CR>", opts)
-map("n", "<leader>h", "<cmd>nohlsearch<CR>", opts)
-
-if utils.is_available "vim-bbye" then
-  map("n", "<leader>c", "<cmd>Bdelete!<CR>", opts)
-end
-
--- Packer
-map("n", "<leader>pc", "<cmd>PackerCompile<cr>", opts)
-map("n", "<leader>pi", "<cmd>PackerInstall<cr>", opts)
-map("n", "<leader>ps", "<cmd>PackerSync<cr>", opts)
-map("n", "<leader>pS", "<cmd>PackerStatus<cr>", opts)
-map("n", "<leader>pu", "<cmd>PackerUpdate<cr>", opts)
-
--- LSP
-map("n", "<leader>lf", "<cmd>lua vim.lsp.buf.formatting_sync()<cr>", opts)
-map("n", "<leader>li", "<cmd>LspInfo<cr>", opts)
-map("n", "<leader>lI", "<cmd>LspInstallInfo<cr>", opts)
-
--- NeoTree
-if utils.is_available "neo-tree.nvim" then
-  map("n", "<leader>e", "<cmd>Neotree toggle<CR>", opts)
-  map("n", "<leader>o", "<cmd>Neotree focus<CR>", opts)
-end
-
--- Dashboard
-if utils.is_available "dashboard-nvim" then
-  map("n", "<leader>d", "<cmd>Dashboard<CR>", opts)
-  map("n", "<leader>fn", "<cmd>DashboardNewFile<CR>", opts)
-  map("n", "<leader>Sl", "<cmd>SessionLoad<CR>", opts)
-  map("n", "<leader>Ss", "<cmd>SessionSave<CR>", opts)
-end
-
--- GitSigns
-if utils.is_available "gitsigns.nvim" then
-  map("n", "<leader>gj", "<cmd>lua require 'gitsigns'.next_hunk()<cr>", opts)
-  map("n", "<leader>gk", "<cmd>lua require 'gitsigns'.prev_hunk()<cr>", opts)
-  map("n", "<leader>gl", "<cmd>lua require 'gitsigns'.blame_line()<cr>", opts)
-  map("n", "<leader>gp", "<cmd>lua require 'gitsigns'.preview_hunk()<cr>", opts)
-  map("n", "<leader>gh", "<cmd>lua require 'gitsigns'.reset_hunk()<cr>", opts)
-  map("n", "<leader>gr", "<cmd>lua require 'gitsigns'.reset_buffer()<cr>", opts)
-  map("n", "<leader>gs", "<cmd>lua require 'gitsigns'.stage_hunk()<cr>", opts)
-  map("n", "<leader>gu", "<cmd>lua require 'gitsigns'.undo_stage_hunk()<cr>", opts)
-  map("n", "<leader>gd", "<cmd>Gitsigns diffthis HEAD<cr>", opts)
-end
-
--- Telescope
-if utils.is_available "telescope.nvim" then
-  map("n", "<leader>fw", "<cmd>Telescope live_grep<CR>", opts)
-  map("n", "<leader>gt", "<cmd>Telescope git_status<CR>", opts)
-  map("n", "<leader>gb", "<cmd>Telescope git_branches<CR>", opts)
-  map("n", "<leader>gc", "<cmd>Telescope git_commits<CR>", opts)
-  map("n", "<leader>ff", "<cmd>Telescope find_files<CR>", opts)
-  map("n", "<leader>fb", "<cmd>Telescope buffers<CR>", opts)
-  map("n", "<leader>fh", "<cmd>Telescope help_tags<CR>", opts)
-  map("n", "<leader>fm", "<cmd>Telescope marks<CR>", opts)
-  map("n", "<leader>fo", "<cmd>Telescope oldfiles<CR>", opts)
-  map("n", "<leader>sb", "<cmd>Telescope git_branches<CR>", opts)
-  map("n", "<leader>sh", "<cmd>Telescope help_tags<CR>", opts)
-  map("n", "<leader>sm", "<cmd>Telescope man_pages<CR>", opts)
-  map("n", "<leader>sn", "<cmd>Telescope notify<CR>", opts)
-  map("n", "<leader>sr", "<cmd>Telescope registers<CR>", opts)
-  map("n", "<leader>sk", "<cmd>Telescope keymaps<CR>", opts)
-  map("n", "<leader>sc", "<cmd>Telescope commands<CR>", opts)
-  map("n", "<leader>ls", "<cmd>Telescope lsp_document_symbols<CR>", opts)
-  map("n", "<leader>lR", "<cmd>Telescope lsp_references<CR>", opts)
-  map("n", "<leader>lD", "<cmd>Telescope diagnostics<CR>", opts)
-end
-
 -- LSP
 map("n", "gD", "<cmd>lua vim.lsp.buf.declaration()<CR>", opts)
 map("n", "gd", "<cmd>lua vim.lsp.buf.definition()<CR>", opts)
@@ -123,16 +52,8 @@ map("n", "]d", "<cmd>lua vim.diagnostic.goto_next({ border = 'rounded' })<CR>", 
 map("n", "gj", "<cmd>lua vim.diagnostic.goto_next({ border = 'rounded' })<cr>", opts)
 map("n", "gk", "<cmd>lua vim.diagnostic.goto_prev({ border = 'rounded' })<cr>", opts)
 map("n", "K", "<cmd>lua vim.lsp.buf.hover()<CR>", opts)
+-- <leader>rn: legacy binding here for backwards compatibility but not in which-key (see <leader>lr)
 map("n", "<leader>rn", "<cmd>lua vim.lsp.buf.rename()<CR>", opts)
-map("n", "<leader>la", "<cmd>lua vim.lsp.buf.code_action()<CR>", opts)
-map("n", "<leader>lr", "<cmd>lua vim.lsp.buf.rename()<CR>", opts)
-map("n", "<leader>ld", "<cmd>lua vim.diagnostic.open_float()<CR>", opts)
-
--- Comment
-if utils.is_available "Comment.nvim" then
-  map("n", "<leader>/", "<cmd>lua require('Comment.api').toggle_current_linewise()<cr>", opts)
-  map("v", "<leader>/", "<esc><cmd>lua require('Comment.api').toggle_linewise_op(vim.fn.visualmode())<CR>", opts)
-end
 
 -- ForceWrite
 map("n", "<C-s>", "<cmd>w!<CR>", opts)
@@ -143,20 +64,109 @@ map("n", "<C-q>", "<cmd>q!<CR>", opts)
 -- Terminal
 if utils.is_available "nvim-toggleterm.lua" then
   map("n", "<C-\\>", "<cmd>ToggleTerm<CR>", opts)
-  map("n", "<leader>gg", "<cmd>lua require('core.utils').toggle_term_cmd('lazygit')<CR>", opts)
-  map("n", "<leader>tn", "<cmd>lua require('core.utils').toggle_term_cmd('node')<CR>", opts)
-  map("n", "<leader>tu", "<cmd>lua require('core.utils').toggle_term_cmd('ncdu')<CR>", opts)
-  map("n", "<leader>tt", "<cmd>lua require('core.utils').toggle_term_cmd('htop')<CR>", opts)
-  map("n", "<leader>tp", "<cmd>lua require('core.utils').toggle_term_cmd('python')<CR>", opts)
-  map("n", "<leader>tl", "<cmd>lua require('core.utils').toggle_term_cmd('lazygit')<CR>", opts)
-  map("n", "<leader>tf", "<cmd>ToggleTerm direction=float<cr>", opts)
-  map("n", "<leader>th", "<cmd>ToggleTerm size=10 direction=horizontal<cr>", opts)
-  map("n", "<leader>tv", "<cmd>ToggleTerm size=80 direction=vertical<cr>", opts)
 end
 
--- SymbolsOutline
-if utils.is_available "symbols-outline.nvim" then
-  map("n", "<leader>lS", "<cmd>SymbolsOutline<CR>", opts)
+-- Normal Leader Mappings --
+-- NOTICE: if changed, update configs/which-key-register.lua
+-- Allows easy user modifications when just overriding which-key
+-- But allows bindings to work for users without which-key
+if not utils.is_available "which-key.nvim" then
+  -- Standard Operations
+  map("n", "<leader>w", "<cmd>w<CR>", opts)
+  map("n", "<leader>q", "<cmd>q<CR>", opts)
+  map("n", "<leader>h", "<cmd>nohlsearch<CR>", opts)
+
+  if utils.is_available "vim-bbye" then
+    map("n", "<leader>c", "<cmd>Bdelete!<CR>", opts)
+  end
+
+  -- Packer
+  map("n", "<leader>pc", "<cmd>PackerCompile<cr>", opts)
+  map("n", "<leader>pi", "<cmd>PackerInstall<cr>", opts)
+  map("n", "<leader>ps", "<cmd>PackerSync<cr>", opts)
+  map("n", "<leader>pS", "<cmd>PackerStatus<cr>", opts)
+  map("n", "<leader>pu", "<cmd>PackerUpdate<cr>", opts)
+
+  -- LSP
+  map("n", "<leader>lf", "<cmd>lua vim.lsp.buf.formatting_sync()<cr>", opts)
+  map("n", "<leader>li", "<cmd>LspInfo<cr>", opts)
+  map("n", "<leader>lI", "<cmd>LspInstallInfo<cr>", opts)
+  map("n", "<leader>la", "<cmd>lua vim.lsp.buf.code_action()<CR>", opts)
+  map("n", "<leader>lr", "<cmd>lua vim.lsp.buf.rename()<CR>", opts)
+  map("n", "<leader>ld", "<cmd>lua vim.diagnostic.open_float()<CR>", opts)
+
+  -- NeoTree
+  if utils.is_available "neo-tree.nvim" then
+    map("n", "<leader>e", "<cmd>Neotree toggle<CR>", opts)
+    map("n", "<leader>o", "<cmd>Neotree focus<CR>", opts)
+  end
+
+  -- Dashboard
+  if utils.is_available "dashboard-nvim" then
+    map("n", "<leader>d", "<cmd>Dashboard<CR>", opts)
+    map("n", "<leader>fn", "<cmd>DashboardNewFile<CR>", opts)
+    map("n", "<leader>Sl", "<cmd>SessionLoad<CR>", opts)
+    map("n", "<leader>Ss", "<cmd>SessionSave<CR>", opts)
+  end
+
+  -- GitSigns
+  if utils.is_available "gitsigns.nvim" then
+    map("n", "<leader>gj", "<cmd>lua require 'gitsigns'.next_hunk()<cr>", opts)
+    map("n", "<leader>gk", "<cmd>lua require 'gitsigns'.prev_hunk()<cr>", opts)
+    map("n", "<leader>gl", "<cmd>lua require 'gitsigns'.blame_line()<cr>", opts)
+    map("n", "<leader>gp", "<cmd>lua require 'gitsigns'.preview_hunk()<cr>", opts)
+    map("n", "<leader>gh", "<cmd>lua require 'gitsigns'.reset_hunk()<cr>", opts)
+    map("n", "<leader>gr", "<cmd>lua require 'gitsigns'.reset_buffer()<cr>", opts)
+    map("n", "<leader>gs", "<cmd>lua require 'gitsigns'.stage_hunk()<cr>", opts)
+    map("n", "<leader>gu", "<cmd>lua require 'gitsigns'.undo_stage_hunk()<cr>", opts)
+    map("n", "<leader>gd", "<cmd>lua require 'gitsigns'.diffthis()<cr>", opts)
+  end
+
+  -- Telescope
+  if utils.is_available "telescope.nvim" then
+    map("n", "<leader>fw", "<cmd>Telescope live_grep<CR>", opts)
+    map("n", "<leader>gt", "<cmd>Telescope git_status<CR>", opts)
+    map("n", "<leader>gb", "<cmd>Telescope git_branches<CR>", opts)
+    map("n", "<leader>gc", "<cmd>Telescope git_commits<CR>", opts)
+    map("n", "<leader>ff", "<cmd>Telescope find_files<CR>", opts)
+    map("n", "<leader>fb", "<cmd>Telescope buffers<CR>", opts)
+    map("n", "<leader>fh", "<cmd>Telescope help_tags<CR>", opts)
+    map("n", "<leader>fm", "<cmd>Telescope marks<CR>", opts)
+    map("n", "<leader>fo", "<cmd>Telescope oldfiles<CR>", opts)
+    map("n", "<leader>sb", "<cmd>Telescope git_branches<CR>", opts)
+    map("n", "<leader>sh", "<cmd>Telescope help_tags<CR>", opts)
+    map("n", "<leader>sm", "<cmd>Telescope man_pages<CR>", opts)
+    map("n", "<leader>sn", "<cmd>Telescope notify<CR>", opts)
+    map("n", "<leader>sr", "<cmd>Telescope registers<CR>", opts)
+    map("n", "<leader>sk", "<cmd>Telescope keymaps<CR>", opts)
+    map("n", "<leader>sc", "<cmd>Telescope commands<CR>", opts)
+    map("n", "<leader>ls", "<cmd>Telescope lsp_document_symbols<CR>", opts)
+    map("n", "<leader>lR", "<cmd>Telescope lsp_references<CR>", opts)
+    map("n", "<leader>lD", "<cmd>Telescope diagnostics<CR>", opts)
+  end
+
+  -- Comment
+  if utils.is_available "Comment.nvim" then
+    map("n", "<leader>/", "<cmd>lua require('Comment.api').toggle_current_linewise()<cr>", opts)
+  end
+
+  -- Terminal
+  if utils.is_available "nvim-toggleterm.lua" then
+    map("n", "<leader>gg", "<cmd>lua require('core.utils').toggle_term_cmd('lazygit')<CR>", opts)
+    map("n", "<leader>tn", "<cmd>lua require('core.utils').toggle_term_cmd('node')<CR>", opts)
+    map("n", "<leader>tu", "<cmd>lua require('core.utils').toggle_term_cmd('ncdu')<CR>", opts)
+    map("n", "<leader>tt", "<cmd>lua require('core.utils').toggle_term_cmd('htop')<CR>", opts)
+    map("n", "<leader>tp", "<cmd>lua require('core.utils').toggle_term_cmd('python')<CR>", opts)
+    map("n", "<leader>tl", "<cmd>lua require('core.utils').toggle_term_cmd('lazygit')<CR>", opts)
+    map("n", "<leader>tf", "<cmd>ToggleTerm direction=float<cr>", opts)
+    map("n", "<leader>th", "<cmd>ToggleTerm size=10 direction=horizontal<cr>", opts)
+    map("n", "<leader>tv", "<cmd>ToggleTerm size=80 direction=vertical<cr>", opts)
+  end
+
+  -- SymbolsOutline
+  if utils.is_available "symbols-outline.nvim" then
+    map("n", "<leader>lS", "<cmd>SymbolsOutline<CR>", opts)
+  end
 end
 
 -- Visual --
@@ -167,6 +177,11 @@ map("v", ">", ">gv", opts)
 -- Move text up and down
 map("v", "<A-j>", "<cmd>m .+1<CR>==", opts)
 map("v", "<A-k>", "<cmd>m .-2<CR>==", opts)
+
+-- Comment
+if utils.is_available "Comment.nvim" then
+  map("v", "<leader>/", "<esc><cmd>lua require('Comment.api').toggle_linewise_op(vim.fn.visualmode())<CR>", opts)
+end
 
 -- Visual Block --
 -- Move text up and down


### PR DESCRIPTION
This sets up which-key assigning mappings if it is available and `mappings.lua` assigning mappings if it is not. This does require core maintenance to duplicate code for leader and non-leader mappings but on the user side if `which-key` is used the user can simply override the which-key register table without also having to unmap or delete mappings as well.