### PR TITLE
Add ability to put user config in ~/.config/astrovim/lua/user

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,5 @@
+vim.opt.rtp:append(vim.fn.stdpath "config" .. "/../astrovim")
+
 local impatient_ok, impatient = pcall(require, "impatient")
 if impatient_ok then
   impatient.enable_profile()


### PR DESCRIPTION
This adds `$XDG_CONFIG_HOME/astrovim` to the runtime path so the user folder can now go in `$XDG_CONFIG_HOME/astrovim/lua/user/`. Note the `$XDG_CONFIG_HOME/astrovim` folder location takes precedence over `$XDG_CONFIG_HOME/nvim`.

Resolves #276 