### PR TITLE
Remove unused localleader from mappings.lua

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -8,7 +8,6 @@ local map = vim.api.nvim_set_keymap
 -- Remap space as leader key
 map("", "<Space>", "<Nop>", opts)
 vim.g.mapleader = " "
-vim.g.maplocalleader = " "
 
 -- Normal --
 if utils.is_available "smart-splits.nvim" then
@@ -202,10 +201,10 @@ function _G.set_terminal_keymaps()
   vim.api.nvim_buf_set_keymap(0, "t", "<C-l>", [[<C-\><C-n><C-W>l]], opts)
 end
 
-vim.cmd [[
-  augroup TermMappings
-    autocmd! TermOpen term://* lua set_terminal_keymaps()
-  augroup END
+vim.cmd [[
+  augroup TermMappings
+    autocmd! TermOpen term://* lua set_terminal_keymaps()
+  augroup END
 ]]
 
 return M


### PR DESCRIPTION
For the use case of including the Nvim-R plugin for working with the R
programming language the plugin makes extensive use of the LocalLeader
mappings. As both the LocalLeader and Global Leader keys are mapped to
" " in Astrovim this introduces conflicts with the existing keybindings when
the filetype plugin is active. As there appears to be no reference to
the localleader mapping throughout the Astrovim repo by removing the
definition the plugin works properly and Astrovim reports no errors
after the change.