### PR TITLE
Fix breaking cmp changes

### DIFF
--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -64,8 +64,10 @@ function M.config()
       behavior = cmp.ConfirmBehavior.Replace,
       select = false,
     },
-    documentation = {
-      border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+    window = {
+      documentation = {
+        border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+      },
     },
     experimental = {
       ghost_text = false,
@@ -81,6 +83,10 @@ function M.config()
       { name = "path" },
     },
     mapping = {
+      ["<Up>"] = cmp.mapping.select_prev_item(),
+      ["<Down>"] = cmp.mapping.select_next_item(),
+      ["<C-p>"] = cmp.mapping.select_prev_item(),
+      ["<C-n>"] = cmp.mapping.select_next_item(),
       ["<C-k>"] = cmp.mapping.select_prev_item(),
       ["<C-j>"] = cmp.mapping.select_next_item(),
       ["<C-d>"] = cmp.mapping(cmp.mapping.scroll_docs(-1), { "i", "c" }),


### PR DESCRIPTION
`cmp` recently had a couple deprecations and breaking changes:

https://github.com/hrsh7th/nvim-cmp/issues/231#issuecomment-1098149666

https://github.com/hrsh7th/nvim-cmp/issues/231#issuecomment-1098175017