### PR TITLE
cmp: Use priorities to order sources

### DIFF
--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -77,10 +77,10 @@ function M.config()
       keyword_length = 1,
     },
     sources = {
-      { name = "nvim_lsp" },
-      { name = "luasnip" },
-      { name = "buffer" },
-      { name = "path" },
+      { name = "nvim_lsp", priority = 1000 },
+      { name = "luasnip", priority = 750 },
+      { name = "buffer", priority = 500 },
+      { name = "path", priority = 250 },
     },
     mapping = {
       ["<Up>"] = cmp.mapping.select_prev_item(),


### PR DESCRIPTION
This makes it easier to add custom sources in the right place. Just add
this into the config section of the plugin that implements the `foobar`
source:

```lua
  local cmp = require "cmp"
  local config = cmp.get_config()
  table.insert(config.sources, { name = "foobar", priority=1100 })
  cmp.setup(config)
```

This will make the `foobar` source show up at the top of the list, while a
priority of 100 will place it at the very bottom.

This avoids having to set the entire list of sources in one place (and
in the right order). That is not very composable. Check popular configs
based on astrovim and you will see this anti-pattern:-)