### PR TITLE
Improve modularity of cmp sources while maintaining priority

### DIFF
--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -76,12 +76,6 @@ function M.config()
     completion = {
       keyword_length = 1,
     },
-    sources = {
-      { name = "nvim_lsp" },
-      { name = "luasnip" },
-      { name = "buffer" },
-      { name = "path" },
-    },
     mapping = {
       ["<Up>"] = cmp.mapping.select_prev_item(),
       ["<Down>"] = cmp.mapping.select_next_item(),

--- a/lua/core/defaults.lua
+++ b/lua/core/defaults.lua
@@ -33,6 +33,15 @@ local config = {
     ts_autotag = true,
   },
 
+  cmp = {
+    source_priority = {
+      nvim_lsp = 1000,
+      luasnip = 750,
+      buffer = 500,
+      path = 250,
+    },
+  },
+
   ui = {
     nui_input = true,
     telescope_select = true,

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -183,24 +183,36 @@ local astro_plugins = {
   {
     "saadparwaiz1/cmp_luasnip",
     after = "nvim-cmp",
+    config = function()
+      require("core.utils").add_user_cmp_source "luasnip"
+    end,
   },
 
   -- Buffer completion source
   {
     "hrsh7th/cmp-buffer",
     after = "nvim-cmp",
+    config = function()
+      require("core.utils").add_user_cmp_source "buffer"
+    end,
   },
 
   -- Path completion source
   {
     "hrsh7th/cmp-path",
     after = "nvim-cmp",
+    config = function()
+      require("core.utils").add_user_cmp_source "path"
+    end,
   },
 
   -- LSP completion source
   {
     "hrsh7th/cmp-nvim-lsp",
     after = "nvim-cmp",
+    config = function()
+      require("core.utils").add_user_cmp_source "nvim_lsp"
+    end,
   },
 
   -- LSP manager

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -165,6 +165,25 @@ function M.toggle_term_cmd(cmd)
   _user_terminals[cmd]:toggle()
 end
 
+function M.add_cmp_source(source, priority)
+  if type(priority) ~= "number" then
+    priority = 1000
+  end
+  local cmp_avail, cmp = pcall(require, "cmp")
+  if cmp_avail then
+    local config = cmp.get_config()
+    table.insert(config.sources, { name = source, priority = priority })
+    cmp.setup(config)
+  end
+end
+
+function M.add_user_cmp_source(source)
+  local priority = M.user_plugin_opts("cmp.source_priority", _user_settings.cmp.source_priority)[source]
+  if priority then
+    M.add_cmp_source(source, priority)
+  end
+end
+
 function M.label_plugins(plugins)
   local labelled = {}
   for _, plugin in ipairs(plugins) do

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -78,6 +78,21 @@ local config = {
     },
   },
 
+  -- CMP Source Priorities
+  -- modify here the priorities of default cmp sources
+  -- higher value == higher priority
+  -- The value can also be set to a boolean for disabling default sources:
+  -- false == disabled
+  -- true == 1000
+  cmp = {
+    source_priority = {
+      nvim_lsp = 1000,
+      luasnip = 750,
+      buffer = 500,
+      path = 250,
+    },
+  },
+
   -- Extend LSP configuration
   lsp = {
     -- add to the server on_attach function


### PR DESCRIPTION
Takes ideas from #291 to move priorities to be more modular while giving the user a means of easily changing the defaults that are chosen through the user config table.